### PR TITLE
TopBuilder: generate component granularity Stores

### DIFF
--- a/test/baseResults/130.frag.out
+++ b/test/baseResults/130.frag.out
@@ -43,9 +43,7 @@ mainBody:                                         ; preds = %entry
   %o = call <4 x float> @llvm.gla.fTexelGather.v4f32.v3f32(i32 4, i32 %0, i32 64, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, i32 undef, float undef)
   store <4 x float> %o, <4 x float>* @o
   %1 = load float* getelementptr inbounds ([4 x float]* @gl_ClipDistance, i32 0, i32 3)
-  %2 = load <4 x float>* @o
-  %o1 = insertelement <4 x float> %2, float %1, i32 1
-  store <4 x float> %o1, <4 x float>* @o
+  store float %1, float* getelementptr inbounds (<4 x float>* @o, i32 0, i32 1)
   call void @"bar3("()
   call void @"bar4("()
   call void @"bar5("()

--- a/test/baseResults/140.frag.out
+++ b/test/baseResults/140.frag.out
@@ -18,43 +18,35 @@ Top IR:
 define fastcc void @main() {
 entry:
   %i1 = alloca float
-  %o5 = alloca float
-  %o1 = alloca i32
+  %o3 = alloca float
+  %o = alloca i32
   %0 = load i1* @gl_FrontFacing
   br i1 %0, label %then, label %else
 
 mainBody:                                         ; preds = %ifmerge
   %1 = load float* getelementptr inbounds ([5 x float]* @gl_ClipDistance, i32 0, i32 2)
-  %2 = load <4 x float>* @o
-  %o = insertelement <4 x float> %2, float %1, i32 1
-  store <4 x float> %o, <4 x float>* @o
-  %3 = load <4 x float>* @k
-  %4 = fptosi <4 x float> %3 to <4 x i32>
-  %5 = load i32* %o1
-  %6 = extractelement <4 x i32> %4, i32 0
-  %7 = getelementptr [5 x float]* @gl_ClipDistance, i32 0, i32 %6
-  %8 = load float* %7
-  %9 = load <4 x float>* @o
-  %o2 = insertelement <4 x float> %9, float %8, i32 2
-  store <4 x float> %o2, <4 x float>* @o
-  %10 = load i32 addrspace(1)* @sampR, !gla.uniform !9
-  %o3 = call <2 x i32> @llvm.gla.queryTextureSizeNoLod.v2i32(i32 5, i32 %10)
-  %11 = load i32 addrspace(1)* @sampB, !gla.uniform !12
-  %o4 = call i32 @llvm.gla.queryTextureSizeNoLod.i32(i32 0, i32 %11)
-  %12 = insertelement <2 x i32> undef, i32 %o4, i32 0
-  %13 = insertelement <2 x i32> %12, i32 %o4, i32 1
-  %14 = add <2 x i32> %o3, %13
-  %15 = sitofp <2 x i32> %14 to <2 x float>
-  %16 = load float* %o5
-  %17 = extractelement <2 x float> %15, i32 0
-  %18 = fdiv float %17, 1.000000e+02
-  %19 = load <4 x float>* @o
-  %o6 = insertelement <4 x float> %19, float %18, i32 3
-  store <4 x float> %o6, <4 x float>* @o
-  %20 = call float @"foo("()
-  %21 = load <4 x float>* @o
-  %o7 = insertelement <4 x float> %21, float %20, i32 2
-  store <4 x float> %o7, <4 x float>* @o
+  store float %1, float* getelementptr inbounds (<4 x float>* @o, i32 0, i32 1)
+  %2 = load <4 x float>* @k
+  %3 = fptosi <4 x float> %2 to <4 x i32>
+  %4 = load i32* %o
+  %5 = extractelement <4 x i32> %3, i32 0
+  %6 = getelementptr [5 x float]* @gl_ClipDistance, i32 0, i32 %5
+  %7 = load float* %6
+  store float %7, float* getelementptr inbounds (<4 x float>* @o, i32 0, i32 2)
+  %8 = load i32 addrspace(1)* @sampR, !gla.uniform !9
+  %o1 = call <2 x i32> @llvm.gla.queryTextureSizeNoLod.v2i32(i32 5, i32 %8)
+  %9 = load i32 addrspace(1)* @sampB, !gla.uniform !12
+  %o2 = call i32 @llvm.gla.queryTextureSizeNoLod.i32(i32 0, i32 %9)
+  %10 = insertelement <2 x i32> undef, i32 %o2, i32 0
+  %11 = insertelement <2 x i32> %10, i32 %o2, i32 1
+  %12 = add <2 x i32> %o1, %11
+  %13 = sitofp <2 x i32> %12 to <2 x float>
+  %14 = load float* %o3
+  %15 = extractelement <2 x float> %13, i32 0
+  %16 = fdiv float %15, 1.000000e+02
+  store float %16, float* getelementptr inbounds (<4 x float>* @o, i32 0, i32 3)
+  %17 = call float @"foo("()
+  store float %17, float* getelementptr inbounds (<4 x float>* @o, i32 0, i32 2)
   br label %stage-epilogue
 
 then:                                             ; preds = %entry
@@ -66,8 +58,8 @@ else:                                             ; preds = %entry
   br label %ifmerge
 
 ifmerge:                                          ; preds = %else, %then
-  %i18 = load float* %i1
-  store float %i18, float* @i1
+  %i14 = load float* %i1
+  store float %i14, float* @i1
   store float 1.020000e+02, float* @i2
   br label %mainBody
 

--- a/test/baseResults/150.vert.out
+++ b/test/baseResults/150.vert.out
@@ -29,10 +29,8 @@ mainBody:                                         ; preds = %entry
   store float %3, float* getelementptr inbounds (%gl_PerVertex* @"anon@0", i32 0, i32 2, i32 2)
   %4 = load i32* %i
   %5 = load float addrspace(2)* @ps, !gla.uniform !37
-  %6 = getelementptr %s2* @s2out, i32 0, i32 1, i32 %4, i32 2, i32 2
-  %7 = load <4 x float>* %6
-  %8 = insertelement <4 x float> %7, float %5, i32 3
-  store <4 x float> %8, <4 x float>* %6
+  %6 = getelementptr %s2* @s2out, i32 0, i32 1, i32 %4, i32 2, i32 2, i32 3
+  store float %5, float* %6
   br label %stage-epilogue
 
 stage-epilogue:                                   ; preds = %mainBody

--- a/test/baseResults/310.comp.out
+++ b/test/baseResults/310.comp.out
@@ -100,12 +100,10 @@ mainBody:                                         ; preds = %entry
   %43 = load <2 x i32> addrspace(4)* @coord2D
   %44 = load <4 x float>* %v
   call void @llvm.gla.imageStoreF.v2i32(i32 2, i32 %42, <2 x i32> %43, <4 x float> %44), !gla.precision !41
-  %45 = load <4 x float> addrspace(3)* getelementptr inbounds (%outbna addrspace(3)* @outbnamena, i32 0, i32 1), !gla.uniform !7
-  %46 = insertelement <4 x float> %45, float 0x4008CCCCC0000000, i32 1
-  %47 = insertelement <4 x float> %46, float 0x4008CCCCC0000000, i32 2
-  store <4 x float> %47, <4 x float> addrspace(3)* getelementptr inbounds (%outbna addrspace(3)* @outbnamena, i32 0, i32 1), !gla.uniform !7
-  %48 = call i32 @llvm.gla.arraylength.p3v3f32(<3 x float> addrspace(3)* getelementptr inbounds (%outb addrspace(3)* @outbname, i32 0, i32 3))
-  store i32 %48, i32 addrspace(3)* getelementptr inbounds (%outbna addrspace(3)* @outbnamena, i32 0, i32 0), !gla.uniform !7
+  store float 0x4008CCCCC0000000, float addrspace(3)* getelementptr inbounds (%outbna addrspace(3)* @outbnamena, i32 0, i32 1, i32 1), !gla.uniform !7
+  store float 0x4008CCCCC0000000, float addrspace(3)* getelementptr inbounds (%outbna addrspace(3)* @outbnamena, i32 0, i32 1, i32 2), !gla.uniform !7
+  %45 = call i32 @llvm.gla.arraylength.p3v3f32(<3 x float> addrspace(3)* getelementptr inbounds (%outb addrspace(3)* @outbname, i32 0, i32 3))
+  store i32 %45, i32 addrspace(3)* getelementptr inbounds (%outbna addrspace(3)* @outbnamena, i32 0, i32 0), !gla.uniform !7
   br label %stage-epilogue
 
 stage-epilogue:                                   ; preds = %mainBody

--- a/test/baseResults/400.frag.out
+++ b/test/baseResults/400.frag.out
@@ -18,7 +18,7 @@ Top IR:
 
 define fastcc void @main() {
 entry:
-  %ioutp8 = alloca <2 x i32>
+  %ioutp6 = alloca <2 x i32>
   %v = alloca <4 x float>
   br label %mainBody
 
@@ -30,62 +30,58 @@ mainBody:                                         ; preds = %entry
   %v2 = call <4 x float> @llvm.gla.fTextureSample.v4f32.v2f32(i32 2, i32 %2, i32 0, <2 x float> %3)
   store <4 x float> %v2, <4 x float>* %v
   %4 = load float* getelementptr inbounds ([2 x float]* @gl_ClipDistance, i32 0, i32 1)
-  %5 = load <4 x float>* @outp
-  %outp = insertelement <4 x float> %5, float %4, i32 0
-  store <4 x float> %outp, <4 x float>* @outp
-  %6 = load <4 x float>* %v
-  %7 = extractelement <4 x float> %6, i32 1
-  %8 = insertelement <3 x float> undef, float %7, i32 0
-  %9 = extractelement <4 x float> %6, i32 2
-  %10 = insertelement <3 x float> %8, float %9, i32 1
-  %11 = extractelement <4 x float> %6, i32 3
-  %12 = insertelement <3 x float> %10, float %11, i32 2
-  %13 = load <4 x float>* @outp
-  %14 = extractelement <3 x float> %12, i32 0
-  %15 = insertelement <4 x float> %13, float %14, i32 1
-  %16 = extractelement <3 x float> %12, i32 1
-  %17 = insertelement <4 x float> %15, float %16, i32 2
-  %18 = extractelement <3 x float> %12, i32 2
-  %outp3 = insertelement <4 x float> %17, float %18, i32 3
-  store <4 x float> %outp3, <4 x float>* @outp
-  %19 = load i32 addrspace(1)* @samp2dr, !gla.uniform !12
-  %20 = load <2 x float>* @c2D
-  %21 = load [4 x <2 x i32>]* @uoutp1
-  %22 = extractvalue [4 x <2 x i32>] %21, 0
-  %23 = extractvalue [4 x <2 x i32>] %21, 1
-  %24 = extractvalue [4 x <2 x i32>] %21, 2
-  %25 = extractvalue [4 x <2 x i32>] %21, 3
-  %uoutp = call <4 x i32> @llvm.gla.texelGatherOffsets.v4i32.v2f32(i32 5, i32 %19, i32 9536, <2 x float> %20, i32 2, float undef, <2 x i32> %22, <2 x i32> %23, <2 x i32> %24, <2 x i32> %25)
+  store float %4, float* getelementptr inbounds (<4 x float>* @outp, i32 0, i32 0)
+  %5 = load <4 x float>* %v
+  %6 = extractelement <4 x float> %5, i32 1
+  %7 = insertelement <3 x float> undef, float %6, i32 0
+  %8 = extractelement <4 x float> %5, i32 2
+  %9 = insertelement <3 x float> %7, float %8, i32 1
+  %10 = extractelement <4 x float> %5, i32 3
+  %11 = insertelement <3 x float> %9, float %10, i32 2
+  %12 = extractelement <3 x float> %11, i32 0
+  store float %12, float* getelementptr inbounds (<4 x float>* @outp, i32 0, i32 1)
+  %13 = extractelement <3 x float> %11, i32 1
+  store float %13, float* getelementptr inbounds (<4 x float>* @outp, i32 0, i32 2)
+  %14 = extractelement <3 x float> %11, i32 2
+  store float %14, float* getelementptr inbounds (<4 x float>* @outp, i32 0, i32 3)
+  %15 = load i32 addrspace(1)* @samp2dr, !gla.uniform !12
+  %16 = load <2 x float>* @c2D
+  %17 = load [4 x <2 x i32>]* @uoutp1
+  %18 = extractvalue [4 x <2 x i32>] %17, 0
+  %19 = extractvalue [4 x <2 x i32>] %17, 1
+  %20 = extractvalue [4 x <2 x i32>] %17, 2
+  %21 = extractvalue [4 x <2 x i32>] %17, 3
+  %uoutp = call <4 x i32> @llvm.gla.texelGatherOffsets.v4i32.v2f32(i32 5, i32 %15, i32 9536, <2 x float> %16, i32 2, float undef, <2 x i32> %18, <2 x i32> %19, <2 x i32> %20, <2 x i32> %21)
   store <4 x i32> %uoutp, <4 x i32>* @uoutp
-  %26 = load i32 addrspace(1)* getelementptr inbounds ([5 x i32] addrspace(1)* @arrayedSampler, i32 0, i32 0), !gla.uniform !9
-  %27 = load <2 x float>* @c2D
-  %outp4 = call <4 x float> @llvm.gla.fTexelGather.v4f32.v2f32(i32 2, i32 %26, i32 64, <2 x float> %27, i32 undef, float undef)
-  %28 = load <4 x float>* @outp
-  %outp5 = fadd <4 x float> %28, %outp4
-  store <4 x float> %outp5, <4 x float>* @outp
-  %29 = load i32 addrspace(1)* @isamp2DA, !gla.uniform !15
-  %ioutp = call <4 x i32> @llvm.gla.texelGatherOffset.v4i32.v3f32(i32 2, i32 %29, i32 1360, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 3, float undef, <2 x i32> <i32 1, i32 1>)
+  %22 = load i32 addrspace(1)* getelementptr inbounds ([5 x i32] addrspace(1)* @arrayedSampler, i32 0, i32 0), !gla.uniform !9
+  %23 = load <2 x float>* @c2D
+  %outp = call <4 x float> @llvm.gla.fTexelGather.v4f32.v2f32(i32 2, i32 %22, i32 64, <2 x float> %23, i32 undef, float undef)
+  %24 = load <4 x float>* @outp
+  %outp3 = fadd <4 x float> %24, %outp
+  store <4 x float> %outp3, <4 x float>* @outp
+  %25 = load i32 addrspace(1)* @isamp2DA, !gla.uniform !15
+  %ioutp = call <4 x i32> @llvm.gla.texelGatherOffset.v4i32.v3f32(i32 2, i32 %25, i32 1360, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 3, float undef, <2 x i32> <i32 1, i32 1>)
   store <4 x i32> %ioutp, <4 x i32>* @ioutp
-  %30 = load i32 addrspace(1)* @isamp2DA, !gla.uniform !15
-  %ioutp6 = call <4 x i32> @llvm.gla.texelGatherOffset.v4i32.v3f32(i32 2, i32 %30, i32 1360, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 3, float undef, <2 x i32> <i32 1, i32 1>)
-  %31 = load <4 x i32>* @ioutp
-  %ioutp7 = add <4 x i32> %31, %ioutp6
-  store <4 x i32> %ioutp7, <4 x i32>* @ioutp
-  %32 = load i32 addrspace(1)* @isamp2DA, !gla.uniform !15
-  %33 = load i32* @i
-  %34 = load <2 x i32>* %ioutp8
-  %35 = insertelement <2 x i32> undef, i32 %33, i32 0
-  %36 = insertelement <2 x i32> %35, i32 %33, i32 1
-  %ioutp9 = call <4 x i32> @llvm.gla.texelGatherOffset.v4i32.v3f32(i32 2, i32 %32, i32 336, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 undef, float undef, <2 x i32> %36)
-  %37 = load <4 x i32>* @ioutp
-  %ioutp10 = add <4 x i32> %37, %ioutp9
-  store <4 x i32> %ioutp10, <4 x i32>* @ioutp
-  %38 = load <4 x float>* @gl_FragCoord
-  %39 = load <4 x float>* @vl2
-  %40 = fadd <4 x float> %38, %39
-  %41 = load <4 x float>* @outp
-  %outp11 = fadd <4 x float> %41, %40
-  store <4 x float> %outp11, <4 x float>* @outp
+  %26 = load i32 addrspace(1)* @isamp2DA, !gla.uniform !15
+  %ioutp4 = call <4 x i32> @llvm.gla.texelGatherOffset.v4i32.v3f32(i32 2, i32 %26, i32 1360, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 3, float undef, <2 x i32> <i32 1, i32 1>)
+  %27 = load <4 x i32>* @ioutp
+  %ioutp5 = add <4 x i32> %27, %ioutp4
+  store <4 x i32> %ioutp5, <4 x i32>* @ioutp
+  %28 = load i32 addrspace(1)* @isamp2DA, !gla.uniform !15
+  %29 = load i32* @i
+  %30 = load <2 x i32>* %ioutp6
+  %31 = insertelement <2 x i32> undef, i32 %29, i32 0
+  %32 = insertelement <2 x i32> %31, i32 %29, i32 1
+  %ioutp7 = call <4 x i32> @llvm.gla.texelGatherOffset.v4i32.v3f32(i32 2, i32 %28, i32 336, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 undef, float undef, <2 x i32> %32)
+  %33 = load <4 x i32>* @ioutp
+  %ioutp8 = add <4 x i32> %33, %ioutp7
+  store <4 x i32> %ioutp8, <4 x i32>* @ioutp
+  %34 = load <4 x float>* @gl_FragCoord
+  %35 = load <4 x float>* @vl2
+  %36 = fadd <4 x float> %34, %35
+  %37 = load <4 x float>* @outp
+  %outp9 = fadd <4 x float> %37, %36
+  store <4 x float> %outp9, <4 x float>* @outp
   call void @"foo23("()
   br label %stage-epilogue
 
@@ -105,9 +101,7 @@ entry:
   %2 = load <4 x float>* @outp
   %3 = extractelement <4 x float> %2, i32 0
   %4 = fadd float %3, %outp
-  %5 = load <4 x float>* @outp
-  %outp1 = insertelement <4 x float> %5, float %4, i32 0
-  store <4 x float> %outp1, <4 x float>* @outp
+  store float %4, float* getelementptr inbounds (<4 x float>* @outp, i32 0, i32 0)
   ret void
 }
 

--- a/test/baseResults/aep.frag.out
+++ b/test/baseResults/aep.frag.out
@@ -45,14 +45,12 @@ mainBody:                                         ; preds = %entry
   %13 = extractelement <4 x float> %8, i32 2, !gla.precision !34
   %14 = insertelement <3 x float> %12, float %13, i32 2, !gla.precision !34
   %15 = fadd <3 x float> %14, %7, !gla.precision !34
-  %16 = load <4 x float>* @color
-  %17 = extractelement <3 x float> %15, i32 0
-  %18 = insertelement <4 x float> %16, float %17, i32 0
-  %19 = extractelement <3 x float> %15, i32 1
-  %20 = insertelement <4 x float> %18, float %19, i32 1
-  %21 = extractelement <3 x float> %15, i32 2
-  %color2 = insertelement <4 x float> %20, float %21, i32 2
-  store <4 x float> %color2, <4 x float>* @color
+  %16 = extractelement <3 x float> %15, i32 0
+  store float %16, float* getelementptr inbounds (<4 x float>* @color, i32 0, i32 0)
+  %17 = extractelement <3 x float> %15, i32 1
+  store float %17, float* getelementptr inbounds (<4 x float>* @color, i32 0, i32 1)
+  %18 = extractelement <3 x float> %15, i32 2
+  store float %18, float* getelementptr inbounds (<4 x float>* @color, i32 0, i32 2)
   br label %stage-epilogue
 
 stage-epilogue:                                   ; preds = %mainBody
@@ -114,12 +112,10 @@ entry:
   %12 = extractelement <4 x float> %9, i32 1, !gla.precision !34
   %13 = insertelement <2 x float> %11, float %12, i32 1, !gla.precision !34
   %14 = fadd <2 x float> %13, %8, !gla.precision !34
-  %15 = load <4 x float>* @color
-  %16 = extractelement <2 x float> %14, i32 0
-  %17 = insertelement <4 x float> %15, float %16, i32 0
-  %18 = extractelement <2 x float> %14, i32 1
-  %color = insertelement <4 x float> %17, float %18, i32 1
-  store <4 x float> %color, <4 x float>* @color
+  %15 = extractelement <2 x float> %14, i32 0
+  store float %15, float* getelementptr inbounds (<4 x float>* @color, i32 0, i32 0)
+  %16 = extractelement <2 x float> %14, i32 1
+  store float %16, float* getelementptr inbounds (<4 x float>* @color, i32 0, i32 1)
   ret void
 }
 

--- a/test/baseResults/earlyReturnDiscard.frag.out
+++ b/test/baseResults/earlyReturnDiscard.frag.out
@@ -62,118 +62,116 @@ ifmerge6:                                         ; preds = %ifmerge
   %11 = load <4 x float>* %color
   %12 = extractelement <4 x float> %11, i32 2
   %13 = fadd float %12, 1.000000e+00
-  %14 = load <4 x float>* %color
-  %color7 = insertelement <4 x float> %14, float %13, i32 2
-  store <4 x float> %color7, <4 x float>* %color
+  %14 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %13, float* %14
   %15 = load <4 x float>* %color
   %16 = extractelement <4 x float> %15, i32 2
   %17 = load float addrspace(2)* @threshhold, !gla.uniform !11
   %18 = fcmp ogt float %16, %17
-  br i1 %18, label %then8, label %ifmerge9
+  br i1 %18, label %then7, label %ifmerge8
 
-then8:                                            ; preds = %ifmerge6
+then7:                                            ; preds = %ifmerge6
   call void @llvm.gla.discard()
   br label %stage-exit
 
 post-discard:                                     ; No predecessors!
   unreachable
 
-ifmerge9:                                         ; preds = %ifmerge6
+ifmerge8:                                         ; preds = %ifmerge6
   %19 = load <4 x float>* %color
-  %color10 = fadd <4 x float> %19, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color10, <4 x float>* %color
+  %color9 = fadd <4 x float> %19, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color9, <4 x float>* %color
   %20 = load <4 x float>* %color
   %21 = extractelement <4 x float> %20, i32 3
   %22 = load float addrspace(2)* @threshhold2, !gla.uniform !12
   %23 = fcmp ogt float %21, %22
-  br i1 %23, label %then11, label %else25
+  br i1 %23, label %then10, label %else23
 
-then11:                                           ; preds = %ifmerge9
+then10:                                           ; preds = %ifmerge8
   %24 = load <4 x float>* %color
   %25 = extractelement <4 x float> %24, i32 2
   %26 = load float addrspace(2)* @threshhold2, !gla.uniform !12
   %27 = fcmp ogt float %25, %26
-  br i1 %27, label %then12, label %else14
+  br i1 %27, label %then11, label %else13
 
-then12:                                           ; preds = %then11
+then11:                                           ; preds = %then10
   br label %stage-epilogue
 
-post-return13:                                    ; No predecessors!
+post-return12:                                    ; No predecessors!
   unreachable
 
-else14:                                           ; preds = %then11
+else13:                                           ; preds = %then10
   %28 = load i1 addrspace(2)* @b, !gla.uniform !13
-  br i1 %28, label %then15, label %else17
+  br i1 %28, label %then14, label %else15
 
-then15:                                           ; preds = %else14
+then14:                                           ; preds = %else13
   %29 = load <4 x float>* %color
   %30 = extractelement <4 x float> %29, i32 2
   %31 = fadd float %30, 1.000000e+00
-  %32 = load <4 x float>* %color
-  %color16 = insertelement <4 x float> %32, float %31, i32 2
-  store <4 x float> %color16, <4 x float>* %color
-  br label %ifmerge23
+  %32 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %31, float* %32
+  br label %ifmerge21
 
-else17:                                           ; preds = %else14
+else15:                                           ; preds = %else13
   %33 = load <4 x float>* %color
   %34 = extractelement <4 x float> %33, i32 0
   %35 = load float addrspace(2)* @minimum, !gla.uniform !10
   %36 = fcmp olt float %34, %35
-  br i1 %36, label %then18, label %else20
+  br i1 %36, label %then16, label %else18
 
-then18:                                           ; preds = %else17
+then16:                                           ; preds = %else15
   call void @llvm.gla.discard()
   br label %stage-exit
 
-post-discard19:                                   ; No predecessors!
+post-discard17:                                   ; No predecessors!
   unreachable
 
-else20:                                           ; preds = %else17
+else18:                                           ; preds = %else15
   %37 = load <4 x float>* %color
-  %color21 = fadd <4 x float> %37, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color21, <4 x float>* %color
+  %color19 = fadd <4 x float> %37, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color19, <4 x float>* %color
+  br label %ifmerge20
+
+ifmerge20:                                        ; preds = %else18
+  br label %ifmerge21
+
+ifmerge21:                                        ; preds = %ifmerge20, %then14
   br label %ifmerge22
 
-ifmerge22:                                        ; preds = %else20
-  br label %ifmerge23
+ifmerge22:                                        ; preds = %ifmerge21
+  br label %ifmerge29
 
-ifmerge23:                                        ; preds = %ifmerge22, %then15
-  br label %ifmerge24
-
-ifmerge24:                                        ; preds = %ifmerge23
-  br label %ifmerge31
-
-else25:                                           ; preds = %ifmerge9
+else23:                                           ; preds = %ifmerge8
   %38 = load i1 addrspace(2)* @b, !gla.uniform !13
-  br i1 %38, label %then26, label %else28
+  br i1 %38, label %then24, label %else26
 
-then26:                                           ; preds = %else25
+then24:                                           ; preds = %else23
   call void @llvm.gla.discard()
   br label %stage-exit
 
-post-discard27:                                   ; No predecessors!
+post-discard25:                                   ; No predecessors!
   unreachable
 
-else28:                                           ; preds = %else25
+else26:                                           ; preds = %else23
   br label %stage-epilogue
 
-post-return29:                                    ; No predecessors!
+post-return27:                                    ; No predecessors!
   unreachable
 
-ifmerge30:                                        ; No predecessors!
-  br label %ifmerge31
+ifmerge28:                                        ; No predecessors!
+  br label %ifmerge29
 
-ifmerge31:                                        ; preds = %ifmerge30, %ifmerge24
+ifmerge29:                                        ; preds = %ifmerge28, %ifmerge22
   %39 = load <4 x float>* %color
   %40 = load <4 x float>* %color2
   %gl_FragColor = fmul <4 x float> %39, %40
   store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor
   br label %stage-epilogue
 
-stage-epilogue:                                   ; preds = %ifmerge31, %else28, %then12, %then5
+stage-epilogue:                                   ; preds = %ifmerge29, %else26, %then11, %then5
   br label %stage-exit
 
-stage-exit:                                       ; preds = %stage-epilogue, %then26, %then18, %then8
+stage-exit:                                       ; preds = %stage-epilogue, %then24, %then16, %then7
   ret void
 }
 

--- a/test/baseResults/forLoop.frag.out
+++ b/test/baseResults/forLoop.frag.out
@@ -11,10 +11,10 @@ Top IR:
 
 define fastcc void @main() {
 entry:
-  %i32 = alloca i32
-  %i23 = alloca i32
+  %i28 = alloca i32
+  %i21 = alloca i32
   %r = alloca <4 x float>
-  %gl_FragColor20 = alloca <4 x float>
+  %gl_FragColor19 = alloca <4 x float>
   %tv4 = alloca <4 x float>
   %i12 = alloca i32
   %i4 = alloca i32
@@ -95,7 +95,7 @@ loop-header13:                                    ; preds = %ifmerge16, %loop-me
   br i1 %18, label %then14, label %ifmerge16
 
 then14:                                           ; preds = %loop-header13
-  br label %loop-merge19
+  br label %loop-merge18
 
 post-loop-break15:                                ; No predecessors!
   unreachable
@@ -107,17 +107,16 @@ ifmerge16:                                        ; preds = %loop-header13
   %22 = extractelement <4 x i32> %21, i32 %20
   %23 = mul i32 %22, 4
   %24 = uitofp i32 %23 to float
-  %25 = load <4 x float>* %tv4
-  %tv417 = insertelement <4 x float> %25, float %24, i32 %19
-  store <4 x float> %tv417, <4 x float>* %tv4
+  %25 = getelementptr <4 x float>* %tv4, i32 0, i32 %19
+  store float %24, float* %25
   %26 = load i32* %i12
-  %i1218 = add i32 %26, 1
-  store i32 %i1218, i32* %i12
+  %i1217 = add i32 %26, 1
+  store i32 %i1217, i32* %i12
   br label %loop-header13
 
-loop-merge19:                                     ; preds = %then14
+loop-merge18:                                     ; preds = %then14
   %27 = load float* %sum
-  %28 = load <4 x float>* %gl_FragColor20
+  %28 = load <4 x float>* %gl_FragColor19
   %29 = insertelement <4 x float> undef, float %27, i32 0
   %30 = insertelement <4 x float> %29, float %27, i32 1
   %31 = insertelement <4 x float> %30, float %27, i32 2
@@ -125,8 +124,8 @@ loop-merge19:                                     ; preds = %then14
   %33 = load <4 x float>* %tv4
   %34 = fadd <4 x float> %32, %33
   %35 = load <4 x float>* @gl_FragColor
-  %gl_FragColor21 = fadd <4 x float> %35, %34
-  store <4 x float> %gl_FragColor21, <4 x float>* @gl_FragColor
+  %gl_FragColor20 = fadd <4 x float> %35, %34
+  store <4 x float> %gl_FragColor20, <4 x float>* @gl_FragColor
   %36 = load <4 x float>* @BaseColor
   %37 = extractelement <4 x float> %36, i32 0
   %38 = insertelement <3 x float> undef, float %37, i32 0
@@ -134,41 +133,41 @@ loop-merge19:                                     ; preds = %then14
   %40 = insertelement <3 x float> %38, float %39, i32 1
   %41 = extractelement <4 x float> %36, i32 2
   %42 = insertelement <3 x float> %40, float %41, i32 2
-  %43 = load <4 x float>* %r
-  %44 = extractelement <3 x float> %42, i32 0
-  %45 = insertelement <4 x float> %43, float %44, i32 0
-  %46 = extractelement <3 x float> %42, i32 1
-  %47 = insertelement <4 x float> %45, float %46, i32 1
-  %48 = extractelement <3 x float> %42, i32 2
-  %r22 = insertelement <4 x float> %47, float %48, i32 2
-  store <4 x float> %r22, <4 x float>* %r
-  store i32 0, i32* %i23
-  br label %loop-header24
+  %43 = extractelement <3 x float> %42, i32 0
+  %44 = getelementptr <4 x float>* %r, i32 0, i32 0
+  store float %43, float* %44
+  %45 = extractelement <3 x float> %42, i32 1
+  %46 = getelementptr <4 x float>* %r, i32 0, i32 1
+  store float %45, float* %46
+  %47 = extractelement <3 x float> %42, i32 2
+  %48 = getelementptr <4 x float>* %r, i32 0, i32 2
+  store float %47, float* %48
+  store i32 0, i32* %i21
+  br label %loop-header22
 
-loop-header24:                                    ; preds = %ifmerge27, %loop-merge19
-  %49 = load i32* %i23
+loop-header22:                                    ; preds = %ifmerge25, %loop-merge18
+  %49 = load i32* %i21
   %50 = load i32 addrspace(2)* @Count, !gla.uniform !5
   %51 = icmp slt i32 %49, %50
   %52 = xor i1 %51, true
-  br i1 %52, label %then25, label %ifmerge27
+  br i1 %52, label %then23, label %ifmerge25
 
-then25:                                           ; preds = %loop-header24
-  br label %loop-merge30
+then23:                                           ; preds = %loop-header22
+  br label %loop-merge27
 
-post-loop-break26:                                ; No predecessors!
+post-loop-break24:                                ; No predecessors!
   unreachable
 
-ifmerge27:                                        ; preds = %loop-header24
+ifmerge25:                                        ; preds = %loop-header22
   %53 = load float* @f
-  %54 = load <4 x float>* %r
-  %r28 = insertelement <4 x float> %54, float %53, i32 3
-  store <4 x float> %r28, <4 x float>* %r
-  %55 = load i32* %i23
-  %i2329 = add i32 %55, 1
-  store i32 %i2329, i32* %i23
-  br label %loop-header24
+  %54 = getelementptr <4 x float>* %r, i32 0, i32 3
+  store float %53, float* %54
+  %55 = load i32* %i21
+  %i2126 = add i32 %55, 1
+  store i32 %i2126, i32* %i21
+  br label %loop-header22
 
-loop-merge30:                                     ; preds = %then25
+loop-merge27:                                     ; preds = %then23
   %56 = load <4 x float>* %r
   %57 = extractelement <4 x float> %56, i32 0
   %58 = insertelement <3 x float> undef, float %57, i32 0
@@ -184,47 +183,45 @@ loop-merge30:                                     ; preds = %then25
   %68 = extractelement <4 x float> %63, i32 2
   %69 = insertelement <3 x float> %67, float %68, i32 2
   %70 = fadd <3 x float> %69, %62
-  %71 = load <4 x float>* @gl_FragColor
-  %72 = extractelement <3 x float> %70, i32 0
-  %73 = insertelement <4 x float> %71, float %72, i32 0
-  %74 = extractelement <3 x float> %70, i32 1
-  %75 = insertelement <4 x float> %73, float %74, i32 1
-  %76 = extractelement <3 x float> %70, i32 2
-  %gl_FragColor31 = insertelement <4 x float> %75, float %76, i32 2
-  store <4 x float> %gl_FragColor31, <4 x float>* @gl_FragColor
-  store i32 0, i32* %i32
-  br label %loop-header33
+  %71 = extractelement <3 x float> %70, i32 0
+  store float %71, float* getelementptr inbounds (<4 x float>* @gl_FragColor, i32 0, i32 0)
+  %72 = extractelement <3 x float> %70, i32 1
+  store float %72, float* getelementptr inbounds (<4 x float>* @gl_FragColor, i32 0, i32 1)
+  %73 = extractelement <3 x float> %70, i32 2
+  store float %73, float* getelementptr inbounds (<4 x float>* @gl_FragColor, i32 0, i32 2)
+  store i32 0, i32* %i28
+  br label %loop-header29
 
-loop-header33:                                    ; preds = %ifmerge36, %loop-merge30
-  %77 = load i32* %i32
-  %78 = icmp slt i32 %77, 16
-  %79 = xor i1 %78, true
-  br i1 %79, label %then34, label %ifmerge36
+loop-header29:                                    ; preds = %ifmerge32, %loop-merge27
+  %74 = load i32* %i28
+  %75 = icmp slt i32 %74, 16
+  %76 = xor i1 %75, true
+  br i1 %76, label %then30, label %ifmerge32
 
-then34:                                           ; preds = %loop-header33
-  br label %loop-merge39
+then30:                                           ; preds = %loop-header29
+  br label %loop-merge35
 
-post-loop-break35:                                ; No predecessors!
+post-loop-break31:                                ; No predecessors!
   unreachable
 
-ifmerge36:                                        ; preds = %loop-header33
-  %80 = load float* @f
-  %81 = load <4 x float>* @gl_FragColor
-  %82 = insertelement <4 x float> undef, float %80, i32 0
-  %83 = insertelement <4 x float> %82, float %80, i32 1
-  %84 = insertelement <4 x float> %83, float %80, i32 2
-  %85 = insertelement <4 x float> %84, float %80, i32 3
-  %gl_FragColor37 = fmul <4 x float> %81, %85
-  store <4 x float> %gl_FragColor37, <4 x float>* @gl_FragColor
-  %86 = load i32* %i32
-  %i3238 = add i32 %86, 4
-  store i32 %i3238, i32* %i32
-  br label %loop-header33
+ifmerge32:                                        ; preds = %loop-header29
+  %77 = load float* @f
+  %78 = load <4 x float>* @gl_FragColor
+  %79 = insertelement <4 x float> undef, float %77, i32 0
+  %80 = insertelement <4 x float> %79, float %77, i32 1
+  %81 = insertelement <4 x float> %80, float %77, i32 2
+  %82 = insertelement <4 x float> %81, float %77, i32 3
+  %gl_FragColor33 = fmul <4 x float> %78, %82
+  store <4 x float> %gl_FragColor33, <4 x float>* @gl_FragColor
+  %83 = load i32* %i28
+  %i2834 = add i32 %83, 4
+  store i32 %i2834, i32* %i28
+  br label %loop-header29
 
-loop-merge39:                                     ; preds = %then34
+loop-merge35:                                     ; preds = %then30
   br label %stage-epilogue
 
-stage-epilogue:                                   ; preds = %loop-merge39
+stage-epilogue:                                   ; preds = %loop-merge35
   br label %stage-exit
 
 stage-exit:                                       ; preds = %stage-epilogue

--- a/test/baseResults/functionSemantics.frag.out
+++ b/test/baseResults/functionSemantics.frag.out
@@ -31,38 +31,34 @@ entry:
 
 mainBody:                                         ; preds = %entry
   store i32 2, i32* %t
-  %0 = getelementptr %s* %f, i32 0, i32 0
-  %1 = load <4 x i32>* %0
-  %2 = insertelement <4 x i32> %1, i32 32, i32 1
-  store <4 x i32> %2, <4 x i32>* %0
+  %0 = getelementptr %s* %f, i32 0, i32 0, i32 1
+  store i32 32, i32* %0
   store i32 1, i32* %param
   store i32 2, i32* %param1
-  %3 = load i32* %t
-  %4 = load i32* %t
-  %param26 = add i32 %3, %4
+  %1 = load i32* %t
+  %2 = load i32* %t
+  %param26 = add i32 %1, %2
   store i32 %param26, i32* %param2
   store i32 8, i32* %param3
-  %5 = getelementptr %s* %f, i32 0, i32 0
-  %6 = load <4 x i32>* %5
-  %param57 = extractelement <4 x i32> %6, i32 1
+  %3 = getelementptr %s* %f, i32 0, i32 0
+  %4 = load <4 x i32>* %3
+  %param57 = extractelement <4 x i32> %4, i32 1
   store i32 %param57, i32* %param5
   %color9 = call i32 @"foo(i1;i1;i1;i1;i1;i1;"(i32* %param, i32* %param1, i32* %param2, i32* %param3, i32* %param4, i32* %param5)
   %e8 = load i32* %param4
   store i32 %e8, i32* %e
-  %7 = load i32* %param5
+  %5 = load i32* %param5
+  %6 = getelementptr %s* %f, i32 0, i32 0, i32 1
+  store i32 %5, i32* %6
+  store i32 %color9, i32* %color
+  %7 = load i32* %e
   %8 = getelementptr %s* %f, i32 0, i32 0
   %9 = load <4 x i32>* %8
-  %10 = insertelement <4 x i32> %9, i32 %7, i32 1
-  store <4 x i32> %10, <4 x i32>* %8
-  store i32 %color9, i32* %color
-  %11 = load i32* %e
-  %12 = getelementptr %s* %f, i32 0, i32 0
-  %13 = load <4 x i32>* %12
-  %14 = extractelement <4 x i32> %13, i32 1
-  %15 = add i32 %11, %14
-  %16 = mul i32 128, %15
-  %17 = load i32* %color
-  %color10 = add i32 %17, %16
+  %10 = extractelement <4 x i32> %9, i32 1
+  %11 = add i32 %7, %10
+  %12 = mul i32 128, %11
+  %13 = load i32* %color
+  %color10 = add i32 %13, %12
   store i32 %color10, i32* %color
   store float 4.000000e+00, float* %param11
   store <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, <3 x float>* %param12
@@ -70,30 +66,30 @@ mainBody:                                         ; preds = %entry
   %tempArg14 = load i32* %param13
   store i32 %tempArg14, i32* %tempArg
   store i32 %tempReturn, i32* @tempReturn
-  %18 = load i32* %tempArg
-  %arg15 = sitofp i32 %18 to float
+  %14 = load i32* %tempArg
+  %arg15 = sitofp i32 %14 to float
   store float %arg15, float* %arg
-  %19 = load i32* @tempReturn
-  %ret16 = sitofp i32 %19 to float
+  %15 = load i32* @tempReturn
+  %ret16 = sitofp i32 %15 to float
   store float %ret16, float* %ret
-  %20 = load float* %ret
-  %21 = load float* %arg
-  %22 = fadd float %20, %21
-  %23 = fptosi float %22 to i32
-  %24 = load i32* %color
-  %color17 = add i32 %24, %23
+  %16 = load float* %ret
+  %17 = load float* %arg
+  %18 = fadd float %16, %17
+  %19 = fptosi float %18 to i32
+  %20 = load i32* %color
+  %color17 = add i32 %20, %19
   store i32 %color17, i32* %color
-  %25 = call i32 @"foo3("()
-  %26 = load i32* %color
-  %color18 = add i32 %26, %25
+  %21 = call i32 @"foo3("()
+  %22 = load i32* %color
+  %color18 = add i32 %22, %21
   store i32 %color18, i32* %color
-  %27 = load i32* %color
-  %28 = sitofp i32 %27 to float
-  %29 = load <4 x float>* %gl_FragColor
-  %30 = insertelement <4 x float> undef, float %28, i32 0
-  %31 = insertelement <4 x float> %30, float %28, i32 1
-  %32 = insertelement <4 x float> %31, float %28, i32 2
-  %gl_FragColor19 = insertelement <4 x float> %32, float %28, i32 3
+  %23 = load i32* %color
+  %24 = sitofp i32 %23 to float
+  %25 = load <4 x float>* %gl_FragColor
+  %26 = insertelement <4 x float> undef, float %24, i32 0
+  %27 = insertelement <4 x float> %26, float %24, i32 1
+  %28 = insertelement <4 x float> %27, float %24, i32 2
+  %gl_FragColor19 = insertelement <4 x float> %28, float %24, i32 3
   store <4 x float> %gl_FragColor19, <4 x float>* @gl_FragColor
   br label %stage-epilogue
 

--- a/test/baseResults/intOps.vert.out
+++ b/test/baseResults/intOps.vert.out
@@ -47,314 +47,270 @@ mainBody:                                         ; preds = %entry
   %6 = extractelement <4 x i32> %3, i32 1, !gla.precision !35
   %7 = insertelement <2 x i32> %5, i32 %6, i32 1, !gla.precision !35
   %8 = add <2 x i32> %7, %2, !gla.precision !35
-  %9 = load <4 x i32>* @uout
-  %10 = extractelement <2 x i32> %8, i32 0
-  %11 = insertelement <4 x i32> %9, i32 %10, i32 0
-  %12 = extractelement <2 x i32> %8, i32 1
-  %uout2 = insertelement <4 x i32> %11, i32 %12, i32 1
-  store <4 x i32> %uout2, <4 x i32>* @uout
-  %13 = load <2 x i32>* %u2out
-  %14 = load <4 x i32>* @uout
-  %15 = extractelement <4 x i32> %14, i32 0, !gla.precision !35
-  %16 = insertelement <2 x i32> undef, i32 %15, i32 0, !gla.precision !35
-  %17 = extractelement <4 x i32> %14, i32 1, !gla.precision !35
-  %18 = insertelement <2 x i32> %16, i32 %17, i32 1, !gla.precision !35
-  %19 = add <2 x i32> %18, %13, !gla.precision !35
-  %20 = load <4 x i32>* @uout
-  %21 = extractelement <2 x i32> %19, i32 0
-  %22 = insertelement <4 x i32> %20, i32 %21, i32 0
-  %23 = extractelement <2 x i32> %19, i32 1
-  %uout3 = insertelement <4 x i32> %22, i32 %23, i32 1
-  store <4 x i32> %uout3, <4 x i32>* @uout
-  %24 = load i32* @u1
-  %25 = load i32* @u1
-  %uout4 = call { i32, i32 } @llvm.gla.subBorrow.i32.i32.i32.i32(i32 %24, i32 %25), !gla.precision !35
-  %u1out5 = extractvalue { i32, i32 } %uout4, 1
-  store i32 %u1out5, i32* %u1out
-  %26 = extractvalue { i32, i32 } %uout4, 0
+  %9 = extractelement <2 x i32> %8, i32 0
+  store i32 %9, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %10 = extractelement <2 x i32> %8, i32 1
+  store i32 %10, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 1)
+  %11 = load <2 x i32>* %u2out
+  %12 = load <4 x i32>* @uout
+  %13 = extractelement <4 x i32> %12, i32 0, !gla.precision !35
+  %14 = insertelement <2 x i32> undef, i32 %13, i32 0, !gla.precision !35
+  %15 = extractelement <4 x i32> %12, i32 1, !gla.precision !35
+  %16 = insertelement <2 x i32> %14, i32 %15, i32 1, !gla.precision !35
+  %17 = add <2 x i32> %16, %11, !gla.precision !35
+  %18 = extractelement <2 x i32> %17, i32 0
+  store i32 %18, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %19 = extractelement <2 x i32> %17, i32 1
+  store i32 %19, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 1)
+  %20 = load i32* @u1
+  %21 = load i32* @u1
+  %uout2 = call { i32, i32 } @llvm.gla.subBorrow.i32.i32.i32.i32(i32 %20, i32 %21), !gla.precision !35
+  %u1out3 = extractvalue { i32, i32 } %uout2, 1
+  store i32 %u1out3, i32* %u1out
+  %22 = extractvalue { i32, i32 } %uout2, 0
+  %23 = load <4 x i32>* @uout
+  %24 = extractelement <4 x i32> %23, i32 0, !gla.precision !35
+  %25 = add i32 %24, %22, !gla.precision !35
+  store i32 %25, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %26 = load i32* %u1out
   %27 = load <4 x i32>* @uout
   %28 = extractelement <4 x i32> %27, i32 0, !gla.precision !35
   %29 = add i32 %28, %26, !gla.precision !35
-  %30 = load <4 x i32>* @uout
-  %uout6 = insertelement <4 x i32> %30, i32 %29, i32 0
+  store i32 %29, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %30 = load <4 x i32>* @u4
+  %31 = load <4 x i32>* @u4
+  %misc2a = call { <4 x i32>, <4 x i32> } @llvm.gla.umulExtended.v4i32.v4i32.v4i32.v4i32(<4 x i32> %30, <4 x i32> %31)
+  %u4out4 = extractvalue { <4 x i32>, <4 x i32> } %misc2a, 0
+  store <4 x i32> %u4out4, <4 x i32>* %u4out
+  %u4out5 = extractvalue { <4 x i32>, <4 x i32> } %misc2a, 1
+  store <4 x i32> %u4out5, <4 x i32>* %u4out
+  %32 = load <4 x i32>* %u4out
+  %33 = load <4 x i32>* @uout
+  %uout6 = add <4 x i32> %33, %32, !gla.precision !35
   store <4 x i32> %uout6, <4 x i32>* @uout
-  %31 = load i32* %u1out
-  %32 = load <4 x i32>* @uout
-  %33 = extractelement <4 x i32> %32, i32 0, !gla.precision !35
-  %34 = add i32 %33, %31, !gla.precision !35
-  %35 = load <4 x i32>* @uout
-  %uout7 = insertelement <4 x i32> %35, i32 %34, i32 0
-  store <4 x i32> %uout7, <4 x i32>* @uout
-  %36 = load <4 x i32>* @u4
-  %37 = load <4 x i32>* @u4
-  %misc2a = call { <4 x i32>, <4 x i32> } @llvm.gla.umulExtended.v4i32.v4i32.v4i32.v4i32(<4 x i32> %36, <4 x i32> %37)
-  %u4out8 = extractvalue { <4 x i32>, <4 x i32> } %misc2a, 0
-  store <4 x i32> %u4out8, <4 x i32>* %u4out
-  %u4out9 = extractvalue { <4 x i32>, <4 x i32> } %misc2a, 1
-  store <4 x i32> %u4out9, <4 x i32>* %u4out
-  %38 = load <4 x i32>* %u4out
-  %39 = load <4 x i32>* @uout
-  %uout10 = add <4 x i32> %39, %38, !gla.precision !35
-  store <4 x i32> %uout10, <4 x i32>* @uout
-  %40 = load <4 x i32>* @i4
-  %41 = load <4 x i32>* @i4
-  %misc2a11 = call { <4 x i32>, <4 x i32> } @llvm.gla.smulExtended.v4i32.v4i32.v4i32.v4i32(<4 x i32> %40, <4 x i32> %41)
-  %i4out112 = extractvalue { <4 x i32>, <4 x i32> } %misc2a11, 0
-  store <4 x i32> %i4out112, <4 x i32>* %i4out1
-  %i4out213 = extractvalue { <4 x i32>, <4 x i32> } %misc2a11, 1
-  store <4 x i32> %i4out213, <4 x i32>* %i4out2
-  %42 = load <4 x i32>* %i4out1
-  %43 = load <4 x i32>* %i4out2
-  %44 = add <4 x i32> %42, %43, !gla.precision !35
-  %45 = load <4 x i32>* @iout
-  %iout = add <4 x i32> %45, %44, !gla.precision !35
+  %34 = load <4 x i32>* @i4
+  %35 = load <4 x i32>* @i4
+  %misc2a7 = call { <4 x i32>, <4 x i32> } @llvm.gla.smulExtended.v4i32.v4i32.v4i32.v4i32(<4 x i32> %34, <4 x i32> %35)
+  %i4out18 = extractvalue { <4 x i32>, <4 x i32> } %misc2a7, 0
+  store <4 x i32> %i4out18, <4 x i32>* %i4out1
+  %i4out29 = extractvalue { <4 x i32>, <4 x i32> } %misc2a7, 1
+  store <4 x i32> %i4out29, <4 x i32>* %i4out2
+  %36 = load <4 x i32>* %i4out1
+  %37 = load <4 x i32>* %i4out2
+  %38 = add <4 x i32> %36, %37, !gla.precision !35
+  %39 = load <4 x i32>* @iout
+  %iout = add <4 x i32> %39, %38, !gla.precision !35
   store <4 x i32> %iout, <4 x i32>* @iout
-  %46 = load i32* @i1
-  %iout14 = call i32 @llvm.gla.sBitFieldExtract.i32.i32(i32 %46, i32 4, i32 5), !gla.precision !35
-  %47 = load <4 x i32>* @iout
-  %48 = extractelement <4 x i32> %47, i32 0, !gla.precision !35
-  %49 = add i32 %48, %iout14, !gla.precision !35
-  %50 = load <4 x i32>* @iout
-  %iout15 = insertelement <4 x i32> %50, i32 %49, i32 0
-  store <4 x i32> %iout15, <4 x i32>* @iout
-  %51 = load <3 x i32>* @u3
-  %uout16 = call <3 x i32> @llvm.gla.uBitFieldExtract.v3i32.v3i32(<3 x i32> %51, i32 4, i32 5), !gla.precision !35
-  %52 = load <4 x i32>* @uout
-  %53 = extractelement <4 x i32> %52, i32 0, !gla.precision !35
-  %54 = insertelement <3 x i32> undef, i32 %53, i32 0, !gla.precision !35
-  %55 = extractelement <4 x i32> %52, i32 1, !gla.precision !35
-  %56 = insertelement <3 x i32> %54, i32 %55, i32 1, !gla.precision !35
-  %57 = extractelement <4 x i32> %52, i32 2, !gla.precision !35
-  %58 = insertelement <3 x i32> %56, i32 %57, i32 2, !gla.precision !35
-  %59 = add <3 x i32> %58, %uout16, !gla.precision !35
-  %60 = load <4 x i32>* @uout
-  %61 = extractelement <3 x i32> %59, i32 0
-  %62 = insertelement <4 x i32> %60, i32 %61, i32 0
-  %63 = extractelement <3 x i32> %59, i32 1
-  %64 = insertelement <4 x i32> %62, i32 %63, i32 1
-  %65 = extractelement <3 x i32> %59, i32 2
-  %uout17 = insertelement <4 x i32> %64, i32 %65, i32 2
-  store <4 x i32> %uout17, <4 x i32>* @uout
-  %66 = load <3 x i32>* @i3
-  %67 = load <3 x i32>* @i3
-  %iout18 = call <3 x i32> @llvm.gla.bitFieldInsert.v3i32.v3i32.v3i32(<3 x i32> %66, <3 x i32> %67, i32 4, i32 5), !gla.precision !35
-  %68 = load <4 x i32>* @iout
-  %69 = extractelement <4 x i32> %68, i32 0, !gla.precision !35
-  %70 = insertelement <3 x i32> undef, i32 %69, i32 0, !gla.precision !35
-  %71 = extractelement <4 x i32> %68, i32 1, !gla.precision !35
-  %72 = insertelement <3 x i32> %70, i32 %71, i32 1, !gla.precision !35
-  %73 = extractelement <4 x i32> %68, i32 2, !gla.precision !35
-  %74 = insertelement <3 x i32> %72, i32 %73, i32 2, !gla.precision !35
-  %75 = add <3 x i32> %74, %iout18, !gla.precision !35
-  %76 = load <4 x i32>* @iout
-  %77 = extractelement <3 x i32> %75, i32 0
-  %78 = insertelement <4 x i32> %76, i32 %77, i32 0
-  %79 = extractelement <3 x i32> %75, i32 1
-  %80 = insertelement <4 x i32> %78, i32 %79, i32 1
-  %81 = extractelement <3 x i32> %75, i32 2
-  %iout19 = insertelement <4 x i32> %80, i32 %81, i32 2
-  store <4 x i32> %iout19, <4 x i32>* @iout
-  %82 = load i32* @u1
-  %83 = load i32* @u1
-  %uout20 = call i32 @llvm.gla.bitFieldInsert.i32.i32.i32(i32 %82, i32 %83, i32 4, i32 5), !gla.precision !35
+  %40 = load i32* @i1
+  %iout10 = call i32 @llvm.gla.sBitFieldExtract.i32.i32(i32 %40, i32 4, i32 5), !gla.precision !35
+  %41 = load <4 x i32>* @iout
+  %42 = extractelement <4 x i32> %41, i32 0, !gla.precision !35
+  %43 = add i32 %42, %iout10, !gla.precision !35
+  store i32 %43, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %44 = load <3 x i32>* @u3
+  %uout11 = call <3 x i32> @llvm.gla.uBitFieldExtract.v3i32.v3i32(<3 x i32> %44, i32 4, i32 5), !gla.precision !35
+  %45 = load <4 x i32>* @uout
+  %46 = extractelement <4 x i32> %45, i32 0, !gla.precision !35
+  %47 = insertelement <3 x i32> undef, i32 %46, i32 0, !gla.precision !35
+  %48 = extractelement <4 x i32> %45, i32 1, !gla.precision !35
+  %49 = insertelement <3 x i32> %47, i32 %48, i32 1, !gla.precision !35
+  %50 = extractelement <4 x i32> %45, i32 2, !gla.precision !35
+  %51 = insertelement <3 x i32> %49, i32 %50, i32 2, !gla.precision !35
+  %52 = add <3 x i32> %51, %uout11, !gla.precision !35
+  %53 = extractelement <3 x i32> %52, i32 0
+  store i32 %53, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %54 = extractelement <3 x i32> %52, i32 1
+  store i32 %54, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 1)
+  %55 = extractelement <3 x i32> %52, i32 2
+  store i32 %55, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 2)
+  %56 = load <3 x i32>* @i3
+  %57 = load <3 x i32>* @i3
+  %iout12 = call <3 x i32> @llvm.gla.bitFieldInsert.v3i32.v3i32.v3i32(<3 x i32> %56, <3 x i32> %57, i32 4, i32 5), !gla.precision !35
+  %58 = load <4 x i32>* @iout
+  %59 = extractelement <4 x i32> %58, i32 0, !gla.precision !35
+  %60 = insertelement <3 x i32> undef, i32 %59, i32 0, !gla.precision !35
+  %61 = extractelement <4 x i32> %58, i32 1, !gla.precision !35
+  %62 = insertelement <3 x i32> %60, i32 %61, i32 1, !gla.precision !35
+  %63 = extractelement <4 x i32> %58, i32 2, !gla.precision !35
+  %64 = insertelement <3 x i32> %62, i32 %63, i32 2, !gla.precision !35
+  %65 = add <3 x i32> %64, %iout12, !gla.precision !35
+  %66 = extractelement <3 x i32> %65, i32 0
+  store i32 %66, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %67 = extractelement <3 x i32> %65, i32 1
+  store i32 %67, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 1)
+  %68 = extractelement <3 x i32> %65, i32 2
+  store i32 %68, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 2)
+  %69 = load i32* @u1
+  %70 = load i32* @u1
+  %uout13 = call i32 @llvm.gla.bitFieldInsert.i32.i32.i32(i32 %69, i32 %70, i32 4, i32 5), !gla.precision !35
+  %71 = load <4 x i32>* @uout
+  %72 = extractelement <4 x i32> %71, i32 0, !gla.precision !35
+  %73 = add i32 %72, %uout13, !gla.precision !35
+  store i32 %73, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %74 = load <2 x i32>* @i2
+  %iout14 = call <2 x i32> @llvm.gla.bitReverse.v2i32.v2i32(<2 x i32> %74), !gla.precision !35
+  %75 = load <4 x i32>* @iout
+  %76 = extractelement <4 x i32> %75, i32 0, !gla.precision !35
+  %77 = insertelement <2 x i32> undef, i32 %76, i32 0, !gla.precision !35
+  %78 = extractelement <4 x i32> %75, i32 1, !gla.precision !35
+  %79 = insertelement <2 x i32> %77, i32 %78, i32 1, !gla.precision !35
+  %80 = add <2 x i32> %79, %iout14, !gla.precision !35
+  %81 = extractelement <2 x i32> %80, i32 0
+  store i32 %81, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %82 = extractelement <2 x i32> %80, i32 1
+  store i32 %82, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 1)
+  %83 = load <4 x i32>* @u4
+  %uout15 = call <4 x i32> @llvm.gla.bitReverse.v4i32.v4i32(<4 x i32> %83), !gla.precision !35
   %84 = load <4 x i32>* @uout
-  %85 = extractelement <4 x i32> %84, i32 0, !gla.precision !35
-  %86 = add i32 %85, %uout20, !gla.precision !35
-  %87 = load <4 x i32>* @uout
-  %uout21 = insertelement <4 x i32> %87, i32 %86, i32 0
-  store <4 x i32> %uout21, <4 x i32>* @uout
-  %88 = load <2 x i32>* @i2
-  %iout22 = call <2 x i32> @llvm.gla.bitReverse.v2i32.v2i32(<2 x i32> %88), !gla.precision !35
-  %89 = load <4 x i32>* @iout
-  %90 = extractelement <4 x i32> %89, i32 0, !gla.precision !35
-  %91 = insertelement <2 x i32> undef, i32 %90, i32 0, !gla.precision !35
-  %92 = extractelement <4 x i32> %89, i32 1, !gla.precision !35
-  %93 = insertelement <2 x i32> %91, i32 %92, i32 1, !gla.precision !35
-  %94 = add <2 x i32> %93, %iout22, !gla.precision !35
-  %95 = load <4 x i32>* @iout
-  %96 = extractelement <2 x i32> %94, i32 0
-  %97 = insertelement <4 x i32> %95, i32 %96, i32 0
-  %98 = extractelement <2 x i32> %94, i32 1
-  %iout23 = insertelement <4 x i32> %97, i32 %98, i32 1
-  store <4 x i32> %iout23, <4 x i32>* @iout
-  %99 = load <4 x i32>* @u4
-  %uout24 = call <4 x i32> @llvm.gla.bitReverse.v4i32.v4i32(<4 x i32> %99), !gla.precision !35
-  %100 = load <4 x i32>* @uout
-  %uout25 = add <4 x i32> %100, %uout24, !gla.precision !35
-  store <4 x i32> %uout25, <4 x i32>* @uout
-  %101 = load i32* @i1
-  %iout26 = call i32 @llvm.gla.bitCount.i32.i32(i32 %101), !gla.precision !35
+  %uout16 = add <4 x i32> %84, %uout15, !gla.precision !35
+  store <4 x i32> %uout16, <4 x i32>* @uout
+  %85 = load i32* @i1
+  %iout17 = call i32 @llvm.gla.bitCount.i32.i32(i32 %85), !gla.precision !35
+  %86 = load <4 x i32>* @iout
+  %87 = extractelement <4 x i32> %86, i32 0, !gla.precision !35
+  %88 = add i32 %87, %iout17, !gla.precision !35
+  store i32 %88, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %89 = load <3 x i32>* @u3
+  %iout18 = call <3 x i32> @llvm.gla.bitCount.v3i32.v3i32(<3 x i32> %89), !gla.precision !35
+  %90 = load <4 x i32>* @iout
+  %91 = extractelement <4 x i32> %90, i32 0, !gla.precision !35
+  %92 = insertelement <3 x i32> undef, i32 %91, i32 0, !gla.precision !35
+  %93 = extractelement <4 x i32> %90, i32 1, !gla.precision !35
+  %94 = insertelement <3 x i32> %92, i32 %93, i32 1, !gla.precision !35
+  %95 = extractelement <4 x i32> %90, i32 2, !gla.precision !35
+  %96 = insertelement <3 x i32> %94, i32 %95, i32 2, !gla.precision !35
+  %97 = add <3 x i32> %96, %iout18, !gla.precision !35
+  %98 = extractelement <3 x i32> %97, i32 0
+  store i32 %98, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %99 = extractelement <3 x i32> %97, i32 1
+  store i32 %99, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 1)
+  %100 = extractelement <3 x i32> %97, i32 2
+  store i32 %100, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 2)
+  %101 = load <2 x i32>* @i2
+  %iout19 = call <2 x i32> @llvm.gla.findLSB.v2i32.v2i32(<2 x i32> %101), !gla.precision !35
   %102 = load <4 x i32>* @iout
   %103 = extractelement <4 x i32> %102, i32 0, !gla.precision !35
-  %104 = add i32 %103, %iout26, !gla.precision !35
-  %105 = load <4 x i32>* @iout
-  %iout27 = insertelement <4 x i32> %105, i32 %104, i32 0
-  store <4 x i32> %iout27, <4 x i32>* @iout
-  %106 = load <3 x i32>* @u3
-  %iout28 = call <3 x i32> @llvm.gla.bitCount.v3i32.v3i32(<3 x i32> %106), !gla.precision !35
-  %107 = load <4 x i32>* @iout
-  %108 = extractelement <4 x i32> %107, i32 0, !gla.precision !35
-  %109 = insertelement <3 x i32> undef, i32 %108, i32 0, !gla.precision !35
-  %110 = extractelement <4 x i32> %107, i32 1, !gla.precision !35
-  %111 = insertelement <3 x i32> %109, i32 %110, i32 1, !gla.precision !35
-  %112 = extractelement <4 x i32> %107, i32 2, !gla.precision !35
-  %113 = insertelement <3 x i32> %111, i32 %112, i32 2, !gla.precision !35
-  %114 = add <3 x i32> %113, %iout28, !gla.precision !35
-  %115 = load <4 x i32>* @iout
-  %116 = extractelement <3 x i32> %114, i32 0
-  %117 = insertelement <4 x i32> %115, i32 %116, i32 0
-  %118 = extractelement <3 x i32> %114, i32 1
-  %119 = insertelement <4 x i32> %117, i32 %118, i32 1
-  %120 = extractelement <3 x i32> %114, i32 2
-  %iout29 = insertelement <4 x i32> %119, i32 %120, i32 2
-  store <4 x i32> %iout29, <4 x i32>* @iout
-  %121 = load <2 x i32>* @i2
-  %iout30 = call <2 x i32> @llvm.gla.findLSB.v2i32.v2i32(<2 x i32> %121), !gla.precision !35
-  %122 = load <4 x i32>* @iout
-  %123 = extractelement <4 x i32> %122, i32 0, !gla.precision !35
-  %124 = insertelement <2 x i32> undef, i32 %123, i32 0, !gla.precision !35
-  %125 = extractelement <4 x i32> %122, i32 1, !gla.precision !35
-  %126 = insertelement <2 x i32> %124, i32 %125, i32 1, !gla.precision !35
-  %127 = add <2 x i32> %126, %iout30, !gla.precision !35
-  %128 = load <4 x i32>* @iout
-  %129 = extractelement <2 x i32> %127, i32 0
-  %130 = insertelement <4 x i32> %128, i32 %129, i32 0
-  %131 = extractelement <2 x i32> %127, i32 1
-  %iout31 = insertelement <4 x i32> %130, i32 %131, i32 1
-  store <4 x i32> %iout31, <4 x i32>* @iout
-  %132 = load <4 x i32>* @u4
-  %iout32 = call <4 x i32> @llvm.gla.findLSB.v4i32.v4i32(<4 x i32> %132), !gla.precision !35
-  %133 = load <4 x i32>* @iout
-  %iout33 = add <4 x i32> %133, %iout32, !gla.precision !35
-  store <4 x i32> %iout33, <4 x i32>* @iout
-  %134 = load i32* @i1
-  %iout34 = call i32 @llvm.gla.sFindMSB.i32.i32(i32 %134), !gla.precision !35
-  %135 = load <4 x i32>* @iout
-  %136 = extractelement <4 x i32> %135, i32 0, !gla.precision !35
-  %137 = add i32 %136, %iout34, !gla.precision !35
-  %138 = load <4 x i32>* @iout
-  %iout35 = insertelement <4 x i32> %138, i32 %137, i32 0
-  store <4 x i32> %iout35, <4 x i32>* @iout
-  %139 = load <2 x i32>* @u2
-  %iout36 = call <2 x i32> @llvm.gla.sFindMSB.v2i32.v2i32(<2 x i32> %139), !gla.precision !35
-  %140 = load <4 x i32>* @iout
-  %141 = extractelement <4 x i32> %140, i32 0, !gla.precision !35
-  %142 = insertelement <2 x i32> undef, i32 %141, i32 0, !gla.precision !35
-  %143 = extractelement <4 x i32> %140, i32 1, !gla.precision !35
-  %144 = insertelement <2 x i32> %142, i32 %143, i32 1, !gla.precision !35
-  %145 = add <2 x i32> %144, %iout36, !gla.precision !35
-  %146 = load <4 x i32>* @iout
-  %147 = extractelement <2 x i32> %145, i32 0
-  %148 = insertelement <4 x i32> %146, i32 %147, i32 0
-  %149 = extractelement <2 x i32> %145, i32 1
-  %iout37 = insertelement <4 x i32> %148, i32 %149, i32 1
-  store <4 x i32> %iout37, <4 x i32>* @iout
-  %150 = load <3 x float>* @v3
-  %fout = call { <3 x float>, <3 x i32> } @llvm.gla.fFrexp.v3f32.v3i32.v3f32(<3 x float> %150), !gla.precision !35
-  %i3out38 = extractvalue { <3 x float>, <3 x i32> } %fout, 1
-  store <3 x i32> %i3out38, <3 x i32>* %i3out
-  %151 = extractvalue { <3 x float>, <3 x i32> } %fout, 0
+  %104 = insertelement <2 x i32> undef, i32 %103, i32 0, !gla.precision !35
+  %105 = extractelement <4 x i32> %102, i32 1, !gla.precision !35
+  %106 = insertelement <2 x i32> %104, i32 %105, i32 1, !gla.precision !35
+  %107 = add <2 x i32> %106, %iout19, !gla.precision !35
+  %108 = extractelement <2 x i32> %107, i32 0
+  store i32 %108, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %109 = extractelement <2 x i32> %107, i32 1
+  store i32 %109, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 1)
+  %110 = load <4 x i32>* @u4
+  %iout20 = call <4 x i32> @llvm.gla.findLSB.v4i32.v4i32(<4 x i32> %110), !gla.precision !35
+  %111 = load <4 x i32>* @iout
+  %iout21 = add <4 x i32> %111, %iout20, !gla.precision !35
+  store <4 x i32> %iout21, <4 x i32>* @iout
+  %112 = load i32* @i1
+  %iout22 = call i32 @llvm.gla.sFindMSB.i32.i32(i32 %112), !gla.precision !35
+  %113 = load <4 x i32>* @iout
+  %114 = extractelement <4 x i32> %113, i32 0, !gla.precision !35
+  %115 = add i32 %114, %iout22, !gla.precision !35
+  store i32 %115, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %116 = load <2 x i32>* @u2
+  %iout23 = call <2 x i32> @llvm.gla.sFindMSB.v2i32.v2i32(<2 x i32> %116), !gla.precision !35
+  %117 = load <4 x i32>* @iout
+  %118 = extractelement <4 x i32> %117, i32 0, !gla.precision !35
+  %119 = insertelement <2 x i32> undef, i32 %118, i32 0, !gla.precision !35
+  %120 = extractelement <4 x i32> %117, i32 1, !gla.precision !35
+  %121 = insertelement <2 x i32> %119, i32 %120, i32 1, !gla.precision !35
+  %122 = add <2 x i32> %121, %iout23, !gla.precision !35
+  %123 = extractelement <2 x i32> %122, i32 0
+  store i32 %123, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %124 = extractelement <2 x i32> %122, i32 1
+  store i32 %124, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 1)
+  %125 = load <3 x float>* @v3
+  %fout = call { <3 x float>, <3 x i32> } @llvm.gla.fFrexp.v3f32.v3i32.v3f32(<3 x float> %125), !gla.precision !35
+  %i3out24 = extractvalue { <3 x float>, <3 x i32> } %fout, 1
+  store <3 x i32> %i3out24, <3 x i32>* %i3out
+  %126 = extractvalue { <3 x float>, <3 x i32> } %fout, 0
+  %127 = load <4 x float>* @fout
+  %128 = extractelement <4 x float> %127, i32 0, !gla.precision !35
+  %129 = insertelement <3 x float> undef, float %128, i32 0, !gla.precision !35
+  %130 = extractelement <4 x float> %127, i32 1, !gla.precision !35
+  %131 = insertelement <3 x float> %129, float %130, i32 1, !gla.precision !35
+  %132 = extractelement <4 x float> %127, i32 2, !gla.precision !35
+  %133 = insertelement <3 x float> %131, float %132, i32 2, !gla.precision !35
+  %134 = fadd <3 x float> %133, %126, !gla.precision !35
+  %135 = extractelement <3 x float> %134, i32 0
+  store float %135, float* getelementptr inbounds (<4 x float>* @fout, i32 0, i32 0)
+  %136 = extractelement <3 x float> %134, i32 1
+  store float %136, float* getelementptr inbounds (<4 x float>* @fout, i32 0, i32 1)
+  %137 = extractelement <3 x float> %134, i32 2
+  store float %137, float* getelementptr inbounds (<4 x float>* @fout, i32 0, i32 2)
+  %138 = load <3 x i32>* %i3out
+  %139 = load <4 x i32>* @iout
+  %140 = extractelement <4 x i32> %139, i32 0, !gla.precision !35
+  %141 = insertelement <3 x i32> undef, i32 %140, i32 0, !gla.precision !35
+  %142 = extractelement <4 x i32> %139, i32 1, !gla.precision !35
+  %143 = insertelement <3 x i32> %141, i32 %142, i32 1, !gla.precision !35
+  %144 = extractelement <4 x i32> %139, i32 2, !gla.precision !35
+  %145 = insertelement <3 x i32> %143, i32 %144, i32 2, !gla.precision !35
+  %146 = add <3 x i32> %145, %138, !gla.precision !35
+  %147 = extractelement <3 x i32> %146, i32 0
+  store i32 %147, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %148 = extractelement <3 x i32> %146, i32 1
+  store i32 %148, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 1)
+  %149 = extractelement <3 x i32> %146, i32 2
+  store i32 %149, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 2)
+  %150 = load float* @v1
+  %fout25 = call { float, i32 } @llvm.gla.fFrexp.f32.i32.f32(float %150), !gla.precision !35
+  %i1out26 = extractvalue { float, i32 } %fout25, 1
+  store i32 %i1out26, i32* %i1out
+  %151 = extractvalue { float, i32 } %fout25, 0
   %152 = load <4 x float>* @fout
   %153 = extractelement <4 x float> %152, i32 0, !gla.precision !35
-  %154 = insertelement <3 x float> undef, float %153, i32 0, !gla.precision !35
-  %155 = extractelement <4 x float> %152, i32 1, !gla.precision !35
-  %156 = insertelement <3 x float> %154, float %155, i32 1, !gla.precision !35
-  %157 = extractelement <4 x float> %152, i32 2, !gla.precision !35
-  %158 = insertelement <3 x float> %156, float %157, i32 2, !gla.precision !35
-  %159 = fadd <3 x float> %158, %151, !gla.precision !35
-  %160 = load <4 x float>* @fout
-  %161 = extractelement <3 x float> %159, i32 0
-  %162 = insertelement <4 x float> %160, float %161, i32 0
-  %163 = extractelement <3 x float> %159, i32 1
-  %164 = insertelement <4 x float> %162, float %163, i32 1
-  %165 = extractelement <3 x float> %159, i32 2
-  %fout39 = insertelement <4 x float> %164, float %165, i32 2
-  store <4 x float> %fout39, <4 x float>* @fout
-  %166 = load <3 x i32>* %i3out
-  %167 = load <4 x i32>* @iout
-  %168 = extractelement <4 x i32> %167, i32 0, !gla.precision !35
-  %169 = insertelement <3 x i32> undef, i32 %168, i32 0, !gla.precision !35
-  %170 = extractelement <4 x i32> %167, i32 1, !gla.precision !35
-  %171 = insertelement <3 x i32> %169, i32 %170, i32 1, !gla.precision !35
-  %172 = extractelement <4 x i32> %167, i32 2, !gla.precision !35
-  %173 = insertelement <3 x i32> %171, i32 %172, i32 2, !gla.precision !35
-  %174 = add <3 x i32> %173, %166, !gla.precision !35
-  %175 = load <4 x i32>* @iout
-  %176 = extractelement <3 x i32> %174, i32 0
-  %177 = insertelement <4 x i32> %175, i32 %176, i32 0
-  %178 = extractelement <3 x i32> %174, i32 1
-  %179 = insertelement <4 x i32> %177, i32 %178, i32 1
-  %180 = extractelement <3 x i32> %174, i32 2
-  %iout40 = insertelement <4 x i32> %179, i32 %180, i32 2
-  store <4 x i32> %iout40, <4 x i32>* @iout
-  %181 = load float* @v1
-  %fout41 = call { float, i32 } @llvm.gla.fFrexp.f32.i32.f32(float %181), !gla.precision !35
-  %i1out42 = extractvalue { float, i32 } %fout41, 1
-  store i32 %i1out42, i32* %i1out
-  %182 = extractvalue { float, i32 } %fout41, 0
+  %154 = fadd float %153, %151, !gla.precision !35
+  store float %154, float* getelementptr inbounds (<4 x float>* @fout, i32 0, i32 0)
+  %155 = load i32* %i1out
+  %156 = load <4 x i32>* @iout
+  %157 = extractelement <4 x i32> %156, i32 0, !gla.precision !35
+  %158 = add i32 %157, %155, !gla.precision !35
+  store i32 %158, i32* getelementptr inbounds (<4 x i32>* @iout, i32 0, i32 0)
+  %159 = load <2 x float>* @v2
+  %160 = load <2 x i32>* @i2
+  %fout27 = call <2 x float> @llvm.gla.fLdexp.v2f32.v2f32.v2i32(<2 x float> %159, <2 x i32> %160), !gla.precision !35
+  %161 = load <4 x float>* @fout
+  %162 = extractelement <4 x float> %161, i32 0, !gla.precision !35
+  %163 = insertelement <2 x float> undef, float %162, i32 0, !gla.precision !35
+  %164 = extractelement <4 x float> %161, i32 1, !gla.precision !35
+  %165 = insertelement <2 x float> %163, float %164, i32 1, !gla.precision !35
+  %166 = fadd <2 x float> %165, %fout27, !gla.precision !35
+  %167 = extractelement <2 x float> %166, i32 0
+  store float %167, float* getelementptr inbounds (<4 x float>* @fout, i32 0, i32 0)
+  %168 = extractelement <2 x float> %166, i32 1
+  store float %168, float* getelementptr inbounds (<4 x float>* @fout, i32 0, i32 1)
+  %169 = load float* @v1
+  %170 = load i32* @i1
+  %fout28 = call float @llvm.gla.fLdexp.f32.f32.i32(float %169, i32 %170), !gla.precision !35
+  %171 = load <4 x float>* @fout
+  %172 = extractelement <4 x float> %171, i32 0, !gla.precision !35
+  %173 = fadd float %172, %fout28, !gla.precision !35
+  store float %173, float* getelementptr inbounds (<4 x float>* @fout, i32 0, i32 0)
+  %174 = load <4 x float>* @v4
+  %uout29 = call i32 @llvm.gla.fPackUnorm4x8.i32.v4f32(<4 x float> %174), !gla.precision !35
+  %175 = load <4 x i32>* @uout
+  %176 = extractelement <4 x i32> %175, i32 0, !gla.precision !35
+  %177 = add i32 %176, %uout29, !gla.precision !35
+  store i32 %177, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %178 = load <4 x float>* @v4
+  %uout30 = call i32 @llvm.gla.fPackSnorm4x8.i32.v4f32(<4 x float> %178), !gla.precision !35
+  %179 = load <4 x i32>* @uout
+  %180 = extractelement <4 x i32> %179, i32 0, !gla.precision !35
+  %181 = add i32 %180, %uout30, !gla.precision !35
+  store i32 %181, i32* getelementptr inbounds (<4 x i32>* @uout, i32 0, i32 0)
+  %182 = load i32* @u1
+  %fout31 = call <4 x float> @llvm.gla.fUnpackUnorm4x8.v4f32.i32(i32 %182), !gla.precision !36
   %183 = load <4 x float>* @fout
-  %184 = extractelement <4 x float> %183, i32 0, !gla.precision !35
-  %185 = fadd float %184, %182, !gla.precision !35
-  %186 = load <4 x float>* @fout
-  %fout43 = insertelement <4 x float> %186, float %185, i32 0
-  store <4 x float> %fout43, <4 x float>* @fout
-  %187 = load i32* %i1out
-  %188 = load <4 x i32>* @iout
-  %189 = extractelement <4 x i32> %188, i32 0, !gla.precision !35
-  %190 = add i32 %189, %187, !gla.precision !35
-  %191 = load <4 x i32>* @iout
-  %iout44 = insertelement <4 x i32> %191, i32 %190, i32 0
-  store <4 x i32> %iout44, <4 x i32>* @iout
-  %192 = load <2 x float>* @v2
-  %193 = load <2 x i32>* @i2
-  %fout45 = call <2 x float> @llvm.gla.fLdexp.v2f32.v2f32.v2i32(<2 x float> %192, <2 x i32> %193), !gla.precision !35
-  %194 = load <4 x float>* @fout
-  %195 = extractelement <4 x float> %194, i32 0, !gla.precision !35
-  %196 = insertelement <2 x float> undef, float %195, i32 0, !gla.precision !35
-  %197 = extractelement <4 x float> %194, i32 1, !gla.precision !35
-  %198 = insertelement <2 x float> %196, float %197, i32 1, !gla.precision !35
-  %199 = fadd <2 x float> %198, %fout45, !gla.precision !35
-  %200 = load <4 x float>* @fout
-  %201 = extractelement <2 x float> %199, i32 0
-  %202 = insertelement <4 x float> %200, float %201, i32 0
-  %203 = extractelement <2 x float> %199, i32 1
-  %fout46 = insertelement <4 x float> %202, float %203, i32 1
-  store <4 x float> %fout46, <4 x float>* @fout
-  %204 = load float* @v1
-  %205 = load i32* @i1
-  %fout47 = call float @llvm.gla.fLdexp.f32.f32.i32(float %204, i32 %205), !gla.precision !35
-  %206 = load <4 x float>* @fout
-  %207 = extractelement <4 x float> %206, i32 0, !gla.precision !35
-  %208 = fadd float %207, %fout47, !gla.precision !35
-  %209 = load <4 x float>* @fout
-  %fout48 = insertelement <4 x float> %209, float %208, i32 0
-  store <4 x float> %fout48, <4 x float>* @fout
-  %210 = load <4 x float>* @v4
-  %uout49 = call i32 @llvm.gla.fPackUnorm4x8.i32.v4f32(<4 x float> %210), !gla.precision !35
-  %211 = load <4 x i32>* @uout
-  %212 = extractelement <4 x i32> %211, i32 0, !gla.precision !35
-  %213 = add i32 %212, %uout49, !gla.precision !35
-  %214 = load <4 x i32>* @uout
-  %uout50 = insertelement <4 x i32> %214, i32 %213, i32 0
-  store <4 x i32> %uout50, <4 x i32>* @uout
-  %215 = load <4 x float>* @v4
-  %uout51 = call i32 @llvm.gla.fPackSnorm4x8.i32.v4f32(<4 x float> %215), !gla.precision !35
-  %216 = load <4 x i32>* @uout
-  %217 = extractelement <4 x i32> %216, i32 0, !gla.precision !35
-  %218 = add i32 %217, %uout51, !gla.precision !35
-  %219 = load <4 x i32>* @uout
-  %uout52 = insertelement <4 x i32> %219, i32 %218, i32 0
-  store <4 x i32> %uout52, <4 x i32>* @uout
-  %220 = load i32* @u1
-  %fout53 = call <4 x float> @llvm.gla.fUnpackUnorm4x8.v4f32.i32(i32 %220), !gla.precision !36
-  %221 = load <4 x float>* @fout
-  %fout54 = fadd <4 x float> %221, %fout53, !gla.precision !35
-  store <4 x float> %fout54, <4 x float>* @fout
-  %222 = load i32* @u1
-  %fout55 = call <4 x float> @llvm.gla.fUnpackSnorm4x8.v4f32.i32(i32 %222), !gla.precision !36
-  %223 = load <4 x float>* @fout
-  %fout56 = fadd <4 x float> %223, %fout55, !gla.precision !35
-  store <4 x float> %fout56, <4 x float>* @fout
+  %fout32 = fadd <4 x float> %183, %fout31, !gla.precision !35
+  store <4 x float> %fout32, <4 x float>* @fout
+  %184 = load i32* @u1
+  %fout33 = call <4 x float> @llvm.gla.fUnpackSnorm4x8.v4f32.i32(i32 %184), !gla.precision !36
+  %185 = load <4 x float>* @fout
+  %fout34 = fadd <4 x float> %185, %fout33, !gla.precision !35
+  store <4 x float> %fout34, <4 x float>* @fout
   br label %stage-epilogue
 
 stage-epilogue:                                   ; preds = %mainBody

--- a/test/baseResults/localAggregates.frag.out
+++ b/test/baseResults/localAggregates.frag.out
@@ -117,34 +117,32 @@ ifmerge9:                                         ; preds = %loop-merge, %then7
   store <4 x float> %31, <4 x float>* %32
   %33 = load <2 x float>* @coord
   %34 = extractelement <2 x float> %33, i32 1
-  %35 = getelementptr %s2* %locals2, i32 0, i32 3
-  %36 = load <4 x float>* %35
-  %37 = insertelement <4 x float> %36, float %34, i32 2
-  store <4 x float> %37, <4 x float>* %35
-  %38 = getelementptr %s2* %locals2, i32 0, i32 3
-  %39 = load <4 x float>* %38
-  %40 = getelementptr [16 x float]* %localFArray, i32 0, i32 4
+  %35 = getelementptr %s2* %locals2, i32 0, i32 3, i32 2
+  store float %34, float* %35
+  %36 = getelementptr %s2* %locals2, i32 0, i32 3
+  %37 = load <4 x float>* %36
+  %38 = getelementptr [16 x float]* %localFArray, i32 0, i32 4
+  %39 = load float* %38
+  %40 = getelementptr %s2* %locals2, i32 0, i32 2, i32 1
   %41 = load float* %40
-  %42 = getelementptr %s2* %locals2, i32 0, i32 2, i32 1
-  %43 = load float* %42
-  %44 = fadd float %41, %43
-  %45 = load i32* %x
-  %46 = getelementptr [16 x float]* %localArray, i32 0, i32 %45
-  %47 = load float* %46
-  %48 = fadd float %44, %47
-  %49 = load i32* %x
-  %50 = getelementptr [16 x float]* %a, i32 0, i32 %49
-  %51 = load float* %50
-  %52 = fadd float %48, %51
-  %53 = insertelement <4 x float> undef, float %52, i32 0
-  %54 = insertelement <4 x float> %53, float %52, i32 1
-  %55 = insertelement <4 x float> %54, float %52, i32 2
-  %56 = insertelement <4 x float> %55, float %52, i32 3
-  %57 = fmul <4 x float> %39, %56
-  %58 = load i32 addrspace(1)* @sampler, !gla.uniform !9
-  %59 = load <2 x float>* @coord
-  %gl_FragColor = call <4 x float> @llvm.gla.fTextureSample.v4f32.v2f32(i32 2, i32 %58, i32 0, <2 x float> %59)
-  %gl_FragColor10 = fmul <4 x float> %57, %gl_FragColor
+  %42 = fadd float %39, %41
+  %43 = load i32* %x
+  %44 = getelementptr [16 x float]* %localArray, i32 0, i32 %43
+  %45 = load float* %44
+  %46 = fadd float %42, %45
+  %47 = load i32* %x
+  %48 = getelementptr [16 x float]* %a, i32 0, i32 %47
+  %49 = load float* %48
+  %50 = fadd float %46, %49
+  %51 = insertelement <4 x float> undef, float %50, i32 0
+  %52 = insertelement <4 x float> %51, float %50, i32 1
+  %53 = insertelement <4 x float> %52, float %50, i32 2
+  %54 = insertelement <4 x float> %53, float %50, i32 3
+  %55 = fmul <4 x float> %37, %54
+  %56 = load i32 addrspace(1)* @sampler, !gla.uniform !9
+  %57 = load <2 x float>* @coord
+  %gl_FragColor = call <4 x float> @llvm.gla.fTextureSample.v4f32.v2f32(i32 2, i32 %56, i32 0, <2 x float> %57)
+  %gl_FragColor10 = fmul <4 x float> %55, %gl_FragColor
   store <4 x float> %gl_FragColor10, <4 x float>* @gl_FragColor
   br label %stage-epilogue
 

--- a/test/baseResults/loops.frag.out
+++ b/test/baseResults/loops.frag.out
@@ -53,10 +53,10 @@ Top IR:
 
 define fastcc void @main() {
 entry:
-  %i107 = alloca i32
-  %i94 = alloca i32
-  %i82 = alloca i32
-  %i67 = alloca i32
+  %i100 = alloca i32
+  %i89 = alloca i32
+  %i79 = alloca i32
+  %i66 = alloca i32
   %i59 = alloca i32
   %i = alloca i32
   %color = alloca <4 x float>
@@ -330,7 +330,7 @@ loop-header60:                                    ; preds = %ifmerge63, %loop-me
   br i1 %74, label %then61, label %ifmerge63
 
 then61:                                           ; preds = %loop-header60
-  br label %loop-merge66
+  br label %loop-merge65
 
 post-loop-break62:                                ; No predecessors!
   unreachable
@@ -340,853 +340,828 @@ ifmerge63:                                        ; preds = %loop-header60
   %76 = load <4 x float>* %color
   %77 = extractelement <4 x float> %76, i32 2
   %78 = fadd float %77, %75
-  %79 = load <4 x float>* %color
-  %color64 = insertelement <4 x float> %79, float %78, i32 2
-  store <4 x float> %color64, <4 x float>* %color
+  %79 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %78, float* %79
   %80 = load i32* %i59
-  %i5965 = add i32 %80, 1
-  store i32 %i5965, i32* %i59
+  %i5964 = add i32 %80, 1
+  store i32 %i5964, i32* %i59
   br label %loop-header60
 
-loop-merge66:                                     ; preds = %then61
-  store i32 0, i32* %i67
-  br label %loop-header68
+loop-merge65:                                     ; preds = %then61
+  store i32 0, i32* %i66
+  br label %loop-header67
 
-loop-header68:                                    ; preds = %ifmerge79, %loop-merge66
-  %81 = load i32* %i67
+loop-header67:                                    ; preds = %ifmerge76, %loop-merge65
+  %81 = load i32* %i66
   %82 = icmp slt i32 %81, 100
   %83 = xor i1 %82, true
-  br i1 %83, label %then69, label %ifmerge71
+  br i1 %83, label %then68, label %ifmerge70
 
-then69:                                           ; preds = %loop-header68
-  br label %loop-merge81
+then68:                                           ; preds = %loop-header67
+  br label %loop-merge78
 
-post-loop-break70:                                ; No predecessors!
+post-loop-break69:                                ; No predecessors!
   unreachable
 
-ifmerge71:                                        ; preds = %loop-header68
+ifmerge70:                                        ; preds = %loop-header67
   %84 = load <4 x float>* %color
   %85 = extractelement <4 x float> %84, i32 2
   %86 = fcmp olt float %85, 2.000000e+01
-  br i1 %86, label %then72, label %else
+  br i1 %86, label %then71, label %else
 
-then72:                                           ; preds = %ifmerge71
+then71:                                           ; preds = %ifmerge70
   %87 = load <4 x float>* %color
   %88 = extractelement <4 x float> %87, i32 0
   %89 = fadd float %88, 1.000000e+00
-  %90 = load <4 x float>* %color
-  %color73 = insertelement <4 x float> %90, float %89, i32 0
-  store <4 x float> %color73, <4 x float>* %color
-  br label %ifmerge75
+  %90 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %89, float* %90
+  br label %ifmerge72
 
-else:                                             ; preds = %ifmerge71
+else:                                             ; preds = %ifmerge70
   %91 = load <4 x float>* %color
   %92 = extractelement <4 x float> %91, i32 1
   %93 = fadd float %92, 1.000000e+00
-  %94 = load <4 x float>* %color
-  %color74 = insertelement <4 x float> %94, float %93, i32 1
-  store <4 x float> %color74, <4 x float>* %color
-  br label %ifmerge75
+  %94 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %93, float* %94
+  br label %ifmerge72
 
-ifmerge75:                                        ; preds = %else, %then72
+ifmerge72:                                        ; preds = %else, %then71
   %95 = load <4 x float>* %color
   %96 = extractelement <4 x float> %95, i32 3
   %97 = fcmp olt float %96, 2.000000e+01
-  br i1 %97, label %then76, label %ifmerge79
+  br i1 %97, label %then73, label %ifmerge76
 
-then76:                                           ; preds = %ifmerge75
+then73:                                           ; preds = %ifmerge72
   %98 = load <4 x float>* %color
   %99 = extractelement <4 x float> %98, i32 2
   %100 = load <4 x float>* %color
   %101 = extractelement <4 x float> %100, i32 1
   %102 = fcmp ogt float %99, %101
-  br i1 %102, label %then77, label %ifmerge78
+  br i1 %102, label %then74, label %ifmerge75
 
-then77:                                           ; preds = %then76
-  br label %ifmerge78
+then74:                                           ; preds = %then73
+  br label %ifmerge75
 
-ifmerge78:                                        ; preds = %then76, %then77
-  br label %ifmerge79
+ifmerge75:                                        ; preds = %then73, %then74
+  br label %ifmerge76
 
-ifmerge79:                                        ; preds = %ifmerge75, %ifmerge78
-  %103 = load i32* %i67
-  %i6780 = add i32 %103, 1
-  store i32 %i6780, i32* %i67
-  br label %loop-header68
+ifmerge76:                                        ; preds = %ifmerge72, %ifmerge75
+  %103 = load i32* %i66
+  %i6677 = add i32 %103, 1
+  store i32 %i6677, i32* %i66
+  br label %loop-header67
 
-loop-merge81:                                     ; preds = %then69
-  store i32 0, i32* %i82
-  br label %loop-header83
+loop-merge78:                                     ; preds = %then68
+  store i32 0, i32* %i79
+  br label %loop-header80
 
-loop-header83:                                    ; preds = %ifmerge91, %loop-merge81
-  %104 = load i32* %i82
+loop-header80:                                    ; preds = %ifmerge86, %loop-merge78
+  %104 = load i32* %i79
   %105 = icmp slt i32 %104, 120
   %106 = xor i1 %105, true
-  br i1 %106, label %then84, label %ifmerge86
+  br i1 %106, label %then81, label %ifmerge83
 
-then84:                                           ; preds = %loop-header83
-  br label %loop-merge93
+then81:                                           ; preds = %loop-header80
+  br label %loop-merge88
 
-post-loop-break85:                                ; No predecessors!
+post-loop-break82:                                ; No predecessors!
   unreachable
 
-ifmerge86:                                        ; preds = %loop-header83
+ifmerge83:                                        ; preds = %loop-header80
   %107 = load <4 x float>* %color
   %108 = extractelement <4 x float> %107, i32 2
   %109 = fcmp olt float %108, 2.000000e+01
-  br i1 %109, label %then87, label %else89
+  br i1 %109, label %then84, label %else85
 
-then87:                                           ; preds = %ifmerge86
+then84:                                           ; preds = %ifmerge83
   %110 = load <4 x float>* %color
   %111 = extractelement <4 x float> %110, i32 0
   %112 = fadd float %111, 1.000000e+00
-  %113 = load <4 x float>* %color
-  %color88 = insertelement <4 x float> %113, float %112, i32 0
-  store <4 x float> %color88, <4 x float>* %color
-  br label %ifmerge91
+  %113 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %112, float* %113
+  br label %ifmerge86
 
-else89:                                           ; preds = %ifmerge86
+else85:                                           ; preds = %ifmerge83
   %114 = load <4 x float>* %color
   %115 = extractelement <4 x float> %114, i32 1
   %116 = fadd float %115, 1.000000e+00
-  %117 = load <4 x float>* %color
-  %color90 = insertelement <4 x float> %117, float %116, i32 1
-  store <4 x float> %color90, <4 x float>* %color
-  br label %ifmerge91
+  %117 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %116, float* %117
+  br label %ifmerge86
 
-ifmerge91:                                        ; preds = %else89, %then87
-  %118 = load i32* %i82
-  %i8292 = add i32 %118, 1
-  store i32 %i8292, i32* %i82
-  br label %loop-header83
+ifmerge86:                                        ; preds = %else85, %then84
+  %118 = load i32* %i79
+  %i7987 = add i32 %118, 1
+  store i32 %i7987, i32* %i79
+  br label %loop-header80
 
-loop-merge93:                                     ; preds = %then84
-  store i32 0, i32* %i94
-  br label %loop-header95
+loop-merge88:                                     ; preds = %then81
+  store i32 0, i32* %i89
+  br label %loop-header90
 
-loop-header95:                                    ; preds = %ifmerge103, %then100, %loop-merge93
-  %119 = load i32* %i94
+loop-header90:                                    ; preds = %ifmerge97, %then94, %loop-merge88
+  %119 = load i32* %i89
   %120 = icmp slt i32 %119, 42
   %121 = xor i1 %120, true
-  br i1 %121, label %then96, label %ifmerge98
+  br i1 %121, label %then91, label %ifmerge93
 
-then96:                                           ; preds = %loop-header95
-  br label %loop-merge106
+then91:                                           ; preds = %loop-header90
+  br label %loop-merge99
 
-post-loop-break97:                                ; No predecessors!
+post-loop-break92:                                ; No predecessors!
   unreachable
 
-ifmerge98:                                        ; preds = %loop-header95
+ifmerge93:                                        ; preds = %loop-header90
   %122 = load float addrspace(2)* @d3, !gla.uniform !8
   %123 = load <4 x float>* %color
   %124 = extractelement <4 x float> %123, i32 2
   %125 = fadd float %124, %122
-  %126 = load <4 x float>* %color
-  %color99 = insertelement <4 x float> %126, float %125, i32 2
-  store <4 x float> %color99, <4 x float>* %color
+  %126 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %125, float* %126
   %127 = load <4 x float>* %color
   %128 = extractelement <4 x float> %127, i32 0
   %129 = load float addrspace(2)* @d4, !gla.uniform !11
   %130 = fcmp olt float %128, %129
-  br i1 %130, label %then100, label %ifmerge103
+  br i1 %130, label %then94, label %ifmerge97
 
-then100:                                          ; preds = %ifmerge98
-  %131 = load i32* %i94
-  %i94101 = add i32 %131, 1
-  store i32 %i94101, i32* %i94
-  br label %loop-header95
+then94:                                           ; preds = %ifmerge93
+  %131 = load i32* %i89
+  %i8995 = add i32 %131, 1
+  store i32 %i8995, i32* %i89
+  br label %loop-header90
 
-post-loop-continue102:                            ; No predecessors!
+post-loop-continue96:                             ; No predecessors!
   unreachable
 
-ifmerge103:                                       ; preds = %ifmerge98
+ifmerge97:                                        ; preds = %ifmerge93
   %132 = load <4 x float>* %color
   %133 = extractelement <4 x float> %132, i32 3
   %134 = fadd float %133, 1.000000e+00
-  %135 = load <4 x float>* %color
-  %color104 = insertelement <4 x float> %135, float %134, i32 3
-  store <4 x float> %color104, <4 x float>* %color
-  %136 = load i32* %i94
-  %i94105 = add i32 %136, 1
-  store i32 %i94105, i32* %i94
-  br label %loop-header95
+  %135 = getelementptr <4 x float>* %color, i32 0, i32 3
+  store float %134, float* %135
+  %136 = load i32* %i89
+  %i8998 = add i32 %136, 1
+  store i32 %i8998, i32* %i89
+  br label %loop-header90
 
-loop-merge106:                                    ; preds = %then96
-  store i32 0, i32* %i107
-  br label %loop-header108
+loop-merge99:                                     ; preds = %then91
+  store i32 0, i32* %i100
+  br label %loop-header101
 
-loop-header108:                                   ; preds = %ifmerge115, %loop-merge106
-  %137 = load i32* %i107
+loop-header101:                                   ; preds = %ifmerge107, %loop-merge99
+  %137 = load i32* %i100
   %138 = icmp slt i32 %137, 42
   %139 = xor i1 %138, true
-  br i1 %139, label %then109, label %ifmerge111
+  br i1 %139, label %then102, label %ifmerge104
 
-then109:                                          ; preds = %loop-header108
-  br label %loop-merge118
+then102:                                          ; preds = %loop-header101
+  br label %loop-merge109
 
-post-loop-break110:                               ; No predecessors!
+post-loop-break103:                               ; No predecessors!
   unreachable
 
-ifmerge111:                                       ; preds = %loop-header108
+ifmerge104:                                       ; preds = %loop-header101
   %140 = load float addrspace(2)* @d3, !gla.uniform !8
   %141 = load <4 x float>* %color
   %142 = extractelement <4 x float> %141, i32 2
   %143 = fadd float %142, %140
-  %144 = load <4 x float>* %color
-  %color112 = insertelement <4 x float> %144, float %143, i32 2
-  store <4 x float> %color112, <4 x float>* %color
+  %144 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %143, float* %144
   %145 = load <4 x float>* %color
   %146 = extractelement <4 x float> %145, i32 0
   %147 = load float addrspace(2)* @d4, !gla.uniform !11
   %148 = fcmp olt float %146, %147
-  br i1 %148, label %then113, label %ifmerge115
+  br i1 %148, label %then105, label %ifmerge107
 
-then113:                                          ; preds = %ifmerge111
-  br label %loop-merge118
+then105:                                          ; preds = %ifmerge104
+  br label %loop-merge109
 
-post-loop-break114:                               ; No predecessors!
+post-loop-break106:                               ; No predecessors!
   unreachable
 
-ifmerge115:                                       ; preds = %ifmerge111
+ifmerge107:                                       ; preds = %ifmerge104
   %149 = load <4 x float>* %color
   %150 = extractelement <4 x float> %149, i32 3
   %151 = fadd float %150, 1.000000e+00
-  %152 = load <4 x float>* %color
-  %color116 = insertelement <4 x float> %152, float %151, i32 3
-  store <4 x float> %color116, <4 x float>* %color
-  %153 = load i32* %i107
-  %i107117 = add i32 %153, 1
-  store i32 %i107117, i32* %i107
-  br label %loop-header108
+  %152 = getelementptr <4 x float>* %color, i32 0, i32 3
+  store float %151, float* %152
+  %153 = load i32* %i100
+  %i100108 = add i32 %153, 1
+  store i32 %i100108, i32* %i100
+  br label %loop-header101
 
-loop-merge118:                                    ; preds = %then113, %then109
-  br label %loop-header119
+loop-merge109:                                    ; preds = %then105, %then102
+  br label %loop-header110
 
-loop-header119:                                   ; preds = %loop-merge118
-  br label %loop-body120
+loop-header110:                                   ; preds = %loop-merge109
+  br label %loop-body111
 
-loop-body120:                                     ; preds = %loop-test130, %loop-header119
+loop-body111:                                     ; preds = %loop-test119, %loop-header110
   %154 = load <4 x float> addrspace(2)* @bigColor4, !gla.uniform !15
   %155 = load <4 x float>* %color
-  %color121 = fadd <4 x float> %155, %154
-  store <4 x float> %color121, <4 x float>* %color
+  %color112 = fadd <4 x float> %155, %154
+  store <4 x float> %color112, <4 x float>* %color
   %156 = load <4 x float>* %color
   %157 = extractelement <4 x float> %156, i32 0
   %158 = load float addrspace(2)* @d4, !gla.uniform !11
   %159 = fcmp olt float %157, %158
-  br i1 %159, label %then122, label %ifmerge124
+  br i1 %159, label %then113, label %ifmerge115
 
-then122:                                          ; preds = %loop-body120
-  br label %loop-test130
+then113:                                          ; preds = %loop-body111
+  br label %loop-test119
 
-post-loop-continue123:                            ; No predecessors!
+post-loop-continue114:                            ; No predecessors!
   unreachable
 
-ifmerge124:                                       ; preds = %loop-body120
+ifmerge115:                                       ; preds = %loop-body111
   %160 = load <4 x float>* %color
   %161 = extractelement <4 x float> %160, i32 1
   %162 = load float addrspace(2)* @d4, !gla.uniform !11
   %163 = fcmp olt float %161, %162
-  br i1 %163, label %then125, label %else127
+  br i1 %163, label %then116, label %else117
 
-then125:                                          ; preds = %ifmerge124
+then116:                                          ; preds = %ifmerge115
   %164 = load float addrspace(2)* @d4, !gla.uniform !11
   %165 = load <4 x float>* %color
   %166 = extractelement <4 x float> %165, i32 1
   %167 = fadd float %166, %164
-  %168 = load <4 x float>* %color
-  %color126 = insertelement <4 x float> %168, float %167, i32 1
-  store <4 x float> %color126, <4 x float>* %color
-  br label %ifmerge129
+  %168 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %167, float* %168
+  br label %ifmerge118
 
-else127:                                          ; preds = %ifmerge124
+else117:                                          ; preds = %ifmerge115
   %169 = load float addrspace(2)* @d4, !gla.uniform !11
   %170 = load <4 x float>* %color
   %171 = extractelement <4 x float> %170, i32 0
   %172 = fadd float %171, %169
-  %173 = load <4 x float>* %color
-  %color128 = insertelement <4 x float> %173, float %172, i32 0
-  store <4 x float> %color128, <4 x float>* %color
-  br label %ifmerge129
+  %173 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %172, float* %173
+  br label %ifmerge118
 
-ifmerge129:                                       ; preds = %else127, %then125
-  br label %loop-test130
+ifmerge118:                                       ; preds = %else117, %then116
+  br label %loop-test119
 
-loop-test130:                                     ; preds = %ifmerge129, %then122
+loop-test119:                                     ; preds = %ifmerge118, %then113
   %174 = load <4 x float>* %color
   %175 = extractelement <4 x float> %174, i32 2
   %176 = load float addrspace(2)* @d4, !gla.uniform !11
   %177 = fcmp olt float %175, %176
-  br i1 %177, label %loop-body120, label %loop-merge131
+  br i1 %177, label %loop-body111, label %loop-merge120
 
-loop-merge131:                                    ; preds = %loop-test130
-  br label %loop-header132
+loop-merge120:                                    ; preds = %loop-test119
+  br label %loop-header121
 
-loop-header132:                                   ; preds = %loop-merge131
-  br label %loop-body133
+loop-header121:                                   ; preds = %loop-merge120
+  br label %loop-body122
 
-loop-body133:                                     ; preds = %loop-test138, %loop-header132
+loop-body122:                                     ; preds = %loop-test126, %loop-header121
   %178 = load <4 x float> addrspace(2)* @bigColor5, !gla.uniform !16
   %179 = load <4 x float>* %color
-  %color134 = fadd <4 x float> %179, %178
-  store <4 x float> %color134, <4 x float>* %color
+  %color123 = fadd <4 x float> %179, %178
+  store <4 x float> %color123, <4 x float>* %color
   %180 = load <4 x float>* %color
   %181 = extractelement <4 x float> %180, i32 1
   %182 = load float addrspace(2)* @d5, !gla.uniform !17
   %183 = fcmp olt float %181, %182
-  br i1 %183, label %then135, label %ifmerge137
+  br i1 %183, label %then124, label %ifmerge125
 
-then135:                                          ; preds = %loop-body133
+then124:                                          ; preds = %loop-body122
   %184 = load float addrspace(2)* @d5, !gla.uniform !17
   %185 = load <4 x float>* %color
   %186 = extractelement <4 x float> %185, i32 1
   %187 = fadd float %186, %184
-  %188 = load <4 x float>* %color
-  %color136 = insertelement <4 x float> %188, float %187, i32 1
-  store <4 x float> %color136, <4 x float>* %color
-  br label %ifmerge137
+  %188 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %187, float* %188
+  br label %ifmerge125
 
-ifmerge137:                                       ; preds = %loop-body133, %then135
-  br label %loop-test138
+ifmerge125:                                       ; preds = %loop-body122, %then124
+  br label %loop-test126
 
-loop-test138:                                     ; preds = %ifmerge137
+loop-test126:                                     ; preds = %ifmerge125
   %189 = load <4 x float>* %color
   %190 = extractelement <4 x float> %189, i32 0
   %191 = load float addrspace(2)* @d5, !gla.uniform !17
   %192 = fcmp olt float %190, %191
-  br i1 %192, label %loop-body133, label %loop-merge139
+  br i1 %192, label %loop-body122, label %loop-merge127
 
-loop-merge139:                                    ; preds = %loop-test138
+loop-merge127:                                    ; preds = %loop-test126
   %193 = load <4 x float>* %color
   %194 = extractelement <4 x float> %193, i32 0
   %195 = load float addrspace(2)* @d6, !gla.uniform !18
   %196 = fcmp olt float %194, %195
-  br i1 %196, label %then140, label %else147
+  br i1 %196, label %then128, label %else135
 
-then140:                                          ; preds = %loop-merge139
-  br label %loop-header141
+then128:                                          ; preds = %loop-merge127
+  br label %loop-header129
 
-loop-header141:                                   ; preds = %ifmerge144, %then140
+loop-header129:                                   ; preds = %ifmerge132, %then128
   %197 = load <4 x float>* %color
   %198 = extractelement <4 x float> %197, i32 1
   %199 = load float addrspace(2)* @d6, !gla.uniform !18
   %200 = fcmp olt float %198, %199
   %201 = xor i1 %200, true
-  br i1 %201, label %then142, label %ifmerge144
+  br i1 %201, label %then130, label %ifmerge132
 
-then142:                                          ; preds = %loop-header141
-  br label %loop-merge146
+then130:                                          ; preds = %loop-header129
+  br label %loop-merge134
 
-post-loop-break143:                               ; No predecessors!
+post-loop-break131:                               ; No predecessors!
   unreachable
 
-ifmerge144:                                       ; preds = %loop-header141
+ifmerge132:                                       ; preds = %loop-header129
   %202 = load <4 x float> addrspace(2)* @bigColor6, !gla.uniform !19
   %203 = load <4 x float>* %color
-  %color145 = fadd <4 x float> %203, %202
-  store <4 x float> %color145, <4 x float>* %color
-  br label %loop-header141
+  %color133 = fadd <4 x float> %203, %202
+  store <4 x float> %color133, <4 x float>* %color
+  br label %loop-header129
 
-loop-merge146:                                    ; preds = %then142
-  br label %ifmerge154
+loop-merge134:                                    ; preds = %then130
+  br label %ifmerge141
 
-else147:                                          ; preds = %loop-merge139
-  br label %loop-header148
+else135:                                          ; preds = %loop-merge127
+  br label %loop-header136
 
-loop-header148:                                   ; preds = %ifmerge151, %else147
+loop-header136:                                   ; preds = %ifmerge139, %else135
   %204 = load <4 x float>* %color
   %205 = extractelement <4 x float> %204, i32 2
   %206 = load float addrspace(2)* @d6, !gla.uniform !18
   %207 = fcmp olt float %205, %206
   %208 = xor i1 %207, true
-  br i1 %208, label %then149, label %ifmerge151
+  br i1 %208, label %then137, label %ifmerge139
 
-then149:                                          ; preds = %loop-header148
-  br label %loop-merge153
+then137:                                          ; preds = %loop-header136
+  br label %loop-merge140
 
-post-loop-break150:                               ; No predecessors!
+post-loop-break138:                               ; No predecessors!
   unreachable
 
-ifmerge151:                                       ; preds = %loop-header148
+ifmerge139:                                       ; preds = %loop-header136
   %209 = load <4 x float> addrspace(2)* @bigColor6, !gla.uniform !19
   %210 = extractelement <4 x float> %209, i32 2
   %211 = load <4 x float>* %color
   %212 = extractelement <4 x float> %211, i32 2
   %213 = fadd float %212, %210
-  %214 = load <4 x float>* %color
-  %color152 = insertelement <4 x float> %214, float %213, i32 2
-  store <4 x float> %color152, <4 x float>* %color
-  br label %loop-header148
+  %214 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %213, float* %214
+  br label %loop-header136
 
-loop-merge153:                                    ; preds = %then149
-  br label %ifmerge154
+loop-merge140:                                    ; preds = %then137
+  br label %ifmerge141
 
-ifmerge154:                                       ; preds = %loop-merge153, %loop-merge146
+ifmerge141:                                       ; preds = %loop-merge140, %loop-merge134
   %215 = load <4 x float>* %color
   %216 = extractelement <4 x float> %215, i32 0
   %217 = load float addrspace(2)* @d6, !gla.uniform !18
   %218 = fcmp olt float %216, %217
-  br i1 %218, label %then155, label %else165
+  br i1 %218, label %then142, label %else152
 
-then155:                                          ; preds = %ifmerge154
-  br label %loop-header156
+then142:                                          ; preds = %ifmerge141
+  br label %loop-header143
 
-loop-header156:                                   ; preds = %ifmerge163, %then155
+loop-header143:                                   ; preds = %ifmerge150, %then142
   %219 = load <4 x float>* %color
   %220 = extractelement <4 x float> %219, i32 1
   %221 = load float addrspace(2)* @d6, !gla.uniform !18
   %222 = fcmp olt float %220, %221
   %223 = xor i1 %222, true
-  br i1 %223, label %then157, label %ifmerge159
+  br i1 %223, label %then144, label %ifmerge146
 
-then157:                                          ; preds = %loop-header156
-  br label %loop-merge164
+then144:                                          ; preds = %loop-header143
+  br label %loop-merge151
 
-post-loop-break158:                               ; No predecessors!
+post-loop-break145:                               ; No predecessors!
   unreachable
 
-ifmerge159:                                       ; preds = %loop-header156
+ifmerge146:                                       ; preds = %loop-header143
   %224 = load <4 x float> addrspace(2)* @bigColor6, !gla.uniform !19
   %225 = load <4 x float>* %color
-  %color160 = fadd <4 x float> %225, %224
-  store <4 x float> %color160, <4 x float>* %color
+  %color147 = fadd <4 x float> %225, %224
+  store <4 x float> %color147, <4 x float>* %color
   %226 = load float addrspace(2)* @d7, !gla.uniform !20
   %227 = fcmp olt float %226, 1.000000e+00
-  br i1 %227, label %then161, label %ifmerge163
+  br i1 %227, label %then148, label %ifmerge150
 
-then161:                                          ; preds = %ifmerge159
-  br label %loop-merge164
+then148:                                          ; preds = %ifmerge146
+  br label %loop-merge151
 
-post-loop-break162:                               ; No predecessors!
+post-loop-break149:                               ; No predecessors!
   unreachable
 
-ifmerge163:                                       ; preds = %ifmerge159
-  br label %loop-header156
+ifmerge150:                                       ; preds = %ifmerge146
+  br label %loop-header143
 
-loop-merge164:                                    ; preds = %then161, %then157
-  br label %ifmerge172
+loop-merge151:                                    ; preds = %then148, %then144
+  br label %ifmerge158
 
-else165:                                          ; preds = %ifmerge154
-  br label %loop-header166
+else152:                                          ; preds = %ifmerge141
+  br label %loop-header153
 
-loop-header166:                                   ; preds = %ifmerge169, %else165
+loop-header153:                                   ; preds = %ifmerge156, %else152
   %228 = load <4 x float>* %color
   %229 = extractelement <4 x float> %228, i32 2
   %230 = load float addrspace(2)* @d6, !gla.uniform !18
   %231 = fcmp olt float %229, %230
   %232 = xor i1 %231, true
-  br i1 %232, label %then167, label %ifmerge169
+  br i1 %232, label %then154, label %ifmerge156
 
-then167:                                          ; preds = %loop-header166
-  br label %loop-merge171
+then154:                                          ; preds = %loop-header153
+  br label %loop-merge157
 
-post-loop-break168:                               ; No predecessors!
+post-loop-break155:                               ; No predecessors!
   unreachable
 
-ifmerge169:                                       ; preds = %loop-header166
+ifmerge156:                                       ; preds = %loop-header153
   %233 = load <4 x float> addrspace(2)* @bigColor6, !gla.uniform !19
   %234 = extractelement <4 x float> %233, i32 2
   %235 = load <4 x float>* %color
   %236 = extractelement <4 x float> %235, i32 2
   %237 = fadd float %236, %234
-  %238 = load <4 x float>* %color
-  %color170 = insertelement <4 x float> %238, float %237, i32 2
-  store <4 x float> %color170, <4 x float>* %color
-  br label %loop-header166
+  %238 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %237, float* %238
+  br label %loop-header153
 
-loop-merge171:                                    ; preds = %then167
-  br label %ifmerge172
+loop-merge157:                                    ; preds = %then154
+  br label %ifmerge158
 
-ifmerge172:                                       ; preds = %loop-merge171, %loop-merge164
-  br label %loop-header173
+ifmerge158:                                       ; preds = %loop-merge157, %loop-merge151
+  br label %loop-header159
 
-loop-header173:                                   ; preds = %ifmerge172
-  br label %loop-body174
+loop-header159:                                   ; preds = %ifmerge158
+  br label %loop-body160
 
-loop-body174:                                     ; preds = %loop-test184, %loop-header173
+loop-body160:                                     ; preds = %loop-test169, %loop-header159
   %239 = load float addrspace(2)* @d7, !gla.uniform !20
   %240 = fcmp olt float %239, 0.000000e+00
-  br i1 %240, label %then175, label %ifmerge177
+  br i1 %240, label %then161, label %ifmerge163
 
-then175:                                          ; preds = %loop-body174
-  br label %loop-merge185
+then161:                                          ; preds = %loop-body160
+  br label %loop-merge170
 
-post-loop-break176:                               ; No predecessors!
+post-loop-break162:                               ; No predecessors!
   unreachable
 
-ifmerge177:                                       ; preds = %loop-body174
+ifmerge163:                                       ; preds = %loop-body160
   %241 = load <4 x float> addrspace(2)* @bigColor7, !gla.uniform !21
   %242 = load <4 x float>* %color
-  %color178 = fadd <4 x float> %242, %241
-  store <4 x float> %color178, <4 x float>* %color
+  %color164 = fadd <4 x float> %242, %241
+  store <4 x float> %color164, <4 x float>* %color
   %243 = load float addrspace(2)* @d7, !gla.uniform !20
   %244 = fcmp olt float %243, 1.000000e+00
-  br i1 %244, label %then179, label %ifmerge182
+  br i1 %244, label %then165, label %ifmerge167
 
-then179:                                          ; preds = %ifmerge177
+then165:                                          ; preds = %ifmerge163
   %245 = load <4 x float>* %color
   %246 = extractelement <4 x float> %245, i32 2
   %247 = fadd float %246, 1.000000e+00
-  %248 = load <4 x float>* %color
-  %color180 = insertelement <4 x float> %248, float %247, i32 2
-  store <4 x float> %color180, <4 x float>* %color
+  %248 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %247, float* %248
+  br label %loop-merge170
+
+post-loop-break166:                               ; No predecessors!
+  unreachable
+
+ifmerge167:                                       ; preds = %ifmerge163
+  %249 = load <4 x float>* @BaseColor
+  %250 = load <4 x float>* %color
+  %color168 = fadd <4 x float> %250, %249
+  store <4 x float> %color168, <4 x float>* %color
+  br label %loop-test169
+
+loop-test169:                                     ; preds = %ifmerge167
+  br i1 true, label %loop-body160, label %loop-merge170
+
+loop-merge170:                                    ; preds = %loop-test169, %then165, %then161
+  br label %loop-header171
+
+loop-header171:                                   ; preds = %loop-merge170
+  br label %loop-body172
+
+loop-body172:                                     ; preds = %loop-test184, %loop-header171
+  %251 = load float addrspace(2)* @d8, !gla.uniform !22
+  %252 = fcmp olt float %251, 0.000000e+00
+  br i1 %252, label %then173, label %ifmerge175
+
+then173:                                          ; preds = %loop-body172
+  br label %loop-merge185
+
+post-loop-break174:                               ; No predecessors!
+  unreachable
+
+ifmerge175:                                       ; preds = %loop-body172
+  %253 = load <4 x float> addrspace(2)* @bigColor7, !gla.uniform !21
+  %254 = load <4 x float>* %color
+  %color176 = fadd <4 x float> %254, %253
+  store <4 x float> %color176, <4 x float>* %color
+  %255 = load float addrspace(2)* @d8, !gla.uniform !22
+  %256 = fcmp olt float %255, 1.000000e+00
+  br i1 %256, label %then177, label %ifmerge182
+
+then177:                                          ; preds = %ifmerge175
+  %257 = load <4 x float>* %color
+  %258 = extractelement <4 x float> %257, i32 2
+  %259 = fadd float %258, 1.000000e+00
+  %260 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %259, float* %260
+  %261 = load float addrspace(2)* @d8, !gla.uniform !22
+  %262 = fcmp olt float %261, 2.000000e+00
+  br i1 %262, label %then178, label %else179
+
+then178:                                          ; preds = %then177
+  %263 = load <4 x float>* %color
+  %264 = extractelement <4 x float> %263, i32 1
+  %265 = fadd float %264, 1.000000e+00
+  %266 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %265, float* %266
+  br label %ifmerge180
+
+else179:                                          ; preds = %then177
+  %267 = load <4 x float>* %color
+  %268 = extractelement <4 x float> %267, i32 0
+  %269 = fadd float %268, 1.000000e+00
+  %270 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %269, float* %270
+  br label %ifmerge180
+
+ifmerge180:                                       ; preds = %else179, %then178
   br label %loop-merge185
 
 post-loop-break181:                               ; No predecessors!
   unreachable
 
-ifmerge182:                                       ; preds = %ifmerge177
-  %249 = load <4 x float>* @BaseColor
-  %250 = load <4 x float>* %color
-  %color183 = fadd <4 x float> %250, %249
+ifmerge182:                                       ; preds = %ifmerge175
+  %271 = load <4 x float>* @BaseColor
+  %272 = load <4 x float>* %color
+  %color183 = fadd <4 x float> %272, %271
   store <4 x float> %color183, <4 x float>* %color
   br label %loop-test184
 
 loop-test184:                                     ; preds = %ifmerge182
-  br i1 true, label %loop-body174, label %loop-merge185
-
-loop-merge185:                                    ; preds = %loop-test184, %then179, %then175
-  br label %loop-header186
-
-loop-header186:                                   ; preds = %loop-merge185
-  br label %loop-body187
-
-loop-body187:                                     ; preds = %loop-test202, %loop-header186
-  %251 = load float addrspace(2)* @d8, !gla.uniform !22
-  %252 = fcmp olt float %251, 0.000000e+00
-  br i1 %252, label %then188, label %ifmerge190
-
-then188:                                          ; preds = %loop-body187
-  br label %loop-merge203
-
-post-loop-break189:                               ; No predecessors!
-  unreachable
-
-ifmerge190:                                       ; preds = %loop-body187
-  %253 = load <4 x float> addrspace(2)* @bigColor7, !gla.uniform !21
-  %254 = load <4 x float>* %color
-  %color191 = fadd <4 x float> %254, %253
-  store <4 x float> %color191, <4 x float>* %color
-  %255 = load float addrspace(2)* @d8, !gla.uniform !22
-  %256 = fcmp olt float %255, 1.000000e+00
-  br i1 %256, label %then192, label %ifmerge200
-
-then192:                                          ; preds = %ifmerge190
-  %257 = load <4 x float>* %color
-  %258 = extractelement <4 x float> %257, i32 2
-  %259 = fadd float %258, 1.000000e+00
-  %260 = load <4 x float>* %color
-  %color193 = insertelement <4 x float> %260, float %259, i32 2
-  store <4 x float> %color193, <4 x float>* %color
-  %261 = load float addrspace(2)* @d8, !gla.uniform !22
-  %262 = fcmp olt float %261, 2.000000e+00
-  br i1 %262, label %then194, label %else196
-
-then194:                                          ; preds = %then192
-  %263 = load <4 x float>* %color
-  %264 = extractelement <4 x float> %263, i32 1
-  %265 = fadd float %264, 1.000000e+00
-  %266 = load <4 x float>* %color
-  %color195 = insertelement <4 x float> %266, float %265, i32 1
-  store <4 x float> %color195, <4 x float>* %color
-  br label %ifmerge198
-
-else196:                                          ; preds = %then192
-  %267 = load <4 x float>* %color
-  %268 = extractelement <4 x float> %267, i32 0
-  %269 = fadd float %268, 1.000000e+00
-  %270 = load <4 x float>* %color
-  %color197 = insertelement <4 x float> %270, float %269, i32 0
-  store <4 x float> %color197, <4 x float>* %color
-  br label %ifmerge198
-
-ifmerge198:                                       ; preds = %else196, %then194
-  br label %loop-merge203
-
-post-loop-break199:                               ; No predecessors!
-  unreachable
-
-ifmerge200:                                       ; preds = %ifmerge190
-  %271 = load <4 x float>* @BaseColor
-  %272 = load <4 x float>* %color
-  %color201 = fadd <4 x float> %272, %271
-  store <4 x float> %color201, <4 x float>* %color
-  br label %loop-test202
-
-loop-test202:                                     ; preds = %ifmerge200
   %273 = load <4 x float>* %color
   %274 = extractelement <4 x float> %273, i32 2
   %275 = load float addrspace(2)* @d8, !gla.uniform !22
   %276 = fcmp olt float %274, %275
-  br i1 %276, label %loop-body187, label %loop-merge203
+  br i1 %276, label %loop-body172, label %loop-merge185
 
-loop-merge203:                                    ; preds = %loop-test202, %ifmerge198, %then188
-  br label %loop-header204
+loop-merge185:                                    ; preds = %loop-test184, %ifmerge180, %then173
+  br label %loop-header186
 
-loop-header204:                                   ; preds = %ifmerge216, %loop-merge203
+loop-header186:                                   ; preds = %ifmerge197, %loop-merge185
   %277 = load <4 x float>* %color
   %278 = extractelement <4 x float> %277, i32 3
   %279 = load float addrspace(2)* @d9, !gla.uniform !23
   %280 = fcmp olt float %278, %279
   %281 = xor i1 %280, true
-  br i1 %281, label %then205, label %ifmerge207
+  br i1 %281, label %then187, label %ifmerge189
 
-then205:                                          ; preds = %loop-header204
-  br label %loop-merge217
+then187:                                          ; preds = %loop-header186
+  br label %loop-merge198
 
-post-loop-break206:                               ; No predecessors!
+post-loop-break188:                               ; No predecessors!
   unreachable
 
-ifmerge207:                                       ; preds = %loop-header204
+ifmerge189:                                       ; preds = %loop-header186
   %282 = load float addrspace(2)* @d9, !gla.uniform !23
   %283 = load float addrspace(2)* @d8, !gla.uniform !22
   %284 = fcmp ogt float %282, %283
-  br i1 %284, label %then208, label %ifmerge216
+  br i1 %284, label %then190, label %ifmerge197
 
-then208:                                          ; preds = %ifmerge207
+then190:                                          ; preds = %ifmerge189
   %285 = load <4 x float>* %color
   %286 = extractelement <4 x float> %285, i32 0
   %287 = load float addrspace(2)* @d7, !gla.uniform !20
   %288 = fcmp ole float %286, %287
-  br i1 %288, label %then209, label %ifmerge215
+  br i1 %288, label %then191, label %ifmerge196
 
-then209:                                          ; preds = %then208
+then191:                                          ; preds = %then190
   %289 = load <4 x float>* %color
   %290 = extractelement <4 x float> %289, i32 2
   %291 = fcmp oeq float %290, 5.000000e+00
-  br i1 %291, label %then210, label %else212
+  br i1 %291, label %then192, label %else193
 
-then210:                                          ; preds = %then209
+then192:                                          ; preds = %then191
   %292 = load <4 x float>* %color
   %293 = extractelement <4 x float> %292, i32 3
   %294 = fadd float %293, 1.000000e+00
-  %295 = load <4 x float>* %color
-  %color211 = insertelement <4 x float> %295, float %294, i32 3
-  store <4 x float> %color211, <4 x float>* %color
-  br label %ifmerge214
+  %295 = getelementptr <4 x float>* %color, i32 0, i32 3
+  store float %294, float* %295
+  br label %ifmerge195
 
-else212:                                          ; preds = %then209
-  br label %loop-merge217
+else193:                                          ; preds = %then191
+  br label %loop-merge198
 
-post-loop-break213:                               ; No predecessors!
+post-loop-break194:                               ; No predecessors!
   unreachable
 
-ifmerge214:                                       ; preds = %then210
-  br label %ifmerge215
+ifmerge195:                                       ; preds = %then192
+  br label %ifmerge196
 
-ifmerge215:                                       ; preds = %then208, %ifmerge214
-  br label %ifmerge216
+ifmerge196:                                       ; preds = %then190, %ifmerge195
+  br label %ifmerge197
 
-ifmerge216:                                       ; preds = %ifmerge207, %ifmerge215
-  br label %loop-header204
+ifmerge197:                                       ; preds = %ifmerge189, %ifmerge196
+  br label %loop-header186
 
-loop-merge217:                                    ; preds = %else212, %then205
-  br label %loop-header218
+loop-merge198:                                    ; preds = %else193, %then187
+  br label %loop-header199
 
-loop-header218:                                   ; preds = %ifmerge229, %loop-merge217
+loop-header199:                                   ; preds = %ifmerge206, %loop-merge198
   %296 = load <4 x float>* %color
   %297 = extractelement <4 x float> %296, i32 2
   %298 = load float addrspace(2)* @d10, !gla.uniform !24
   %299 = fcmp olt float %297, %298
   %300 = xor i1 %299, true
-  br i1 %300, label %then219, label %ifmerge221
+  br i1 %300, label %then200, label %ifmerge202
 
-then219:                                          ; preds = %loop-header218
-  br label %loop-merge234
+then200:                                          ; preds = %loop-header199
+  br label %loop-merge211
 
-post-loop-break220:                               ; No predecessors!
+post-loop-break201:                               ; No predecessors!
   unreachable
 
-ifmerge221:                                       ; preds = %loop-header218
+ifmerge202:                                       ; preds = %loop-header199
   %301 = load <4 x float>* %color
   %302 = extractelement <4 x float> %301, i32 1
   %303 = fadd float %302, 1.000000e+00
-  %304 = load <4 x float>* %color
-  %color222 = insertelement <4 x float> %304, float %303, i32 1
-  store <4 x float> %color222, <4 x float>* %color
+  %304 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %303, float* %304
   %305 = load <4 x float>* %color
   %306 = extractelement <4 x float> %305, i32 1
   %307 = load float addrspace(2)* @d11, !gla.uniform !25
   %308 = fcmp olt float %306, %307
-  br i1 %308, label %then223, label %ifmerge231
+  br i1 %308, label %then203, label %ifmerge208
 
-then223:                                          ; preds = %ifmerge221
+then203:                                          ; preds = %ifmerge202
   %309 = load <4 x float>* %color
   %310 = extractelement <4 x float> %309, i32 2
   %311 = fadd float %310, 1.000000e+00
-  %312 = load <4 x float>* %color
-  %color224 = insertelement <4 x float> %312, float %311, i32 2
-  store <4 x float> %color224, <4 x float>* %color
+  %312 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %311, float* %312
   %313 = load <4 x float>* %color
   %314 = extractelement <4 x float> %313, i32 3
   %315 = load float addrspace(2)* @d12, !gla.uniform !26
   %316 = fcmp olt float %314, %315
-  br i1 %316, label %then225, label %else227
+  br i1 %316, label %then204, label %else205
 
-then225:                                          ; preds = %then223
+then204:                                          ; preds = %then203
   %317 = load <4 x float>* %color
   %318 = extractelement <4 x float> %317, i32 3
   %319 = fadd float %318, 1.000000e+00
-  %320 = load <4 x float>* %color
-  %color226 = insertelement <4 x float> %320, float %319, i32 3
-  store <4 x float> %color226, <4 x float>* %color
-  br label %ifmerge229
+  %320 = getelementptr <4 x float>* %color, i32 0, i32 3
+  store float %319, float* %320
+  br label %ifmerge206
 
-else227:                                          ; preds = %then223
+else205:                                          ; preds = %then203
   %321 = load <4 x float>* %color
   %322 = extractelement <4 x float> %321, i32 0
   %323 = fadd float %322, 1.000000e+00
-  %324 = load <4 x float>* %color
-  %color228 = insertelement <4 x float> %324, float %323, i32 0
-  store <4 x float> %color228, <4 x float>* %color
-  br label %ifmerge229
+  %324 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %323, float* %324
+  br label %ifmerge206
 
-ifmerge229:                                       ; preds = %else227, %then225
-  br label %loop-header218
+ifmerge206:                                       ; preds = %else205, %then204
+  br label %loop-header199
 
-post-loop-continue230:                            ; No predecessors!
+post-loop-continue207:                            ; No predecessors!
   unreachable
 
-ifmerge231:                                       ; preds = %ifmerge221
+ifmerge208:                                       ; preds = %ifmerge202
   %325 = load <4 x float>* %color
-  %color232 = fadd <4 x float> %325, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color232, <4 x float>* %color
-  br label %loop-merge234
+  %color209 = fadd <4 x float> %325, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color209, <4 x float>* %color
+  br label %loop-merge211
 
-post-loop-break233:                               ; No predecessors!
+post-loop-break210:                               ; No predecessors!
   unreachable
 
-loop-merge234:                                    ; preds = %ifmerge231, %then219
-  br label %loop-header235
+loop-merge211:                                    ; preds = %ifmerge208, %then200
+  br label %loop-header212
 
-loop-header235:                                   ; preds = %ifmerge244, %then241, %loop-merge234
+loop-header212:                                   ; preds = %ifmerge221, %then218, %loop-merge211
   %326 = load <4 x float>* %color
   %327 = extractelement <4 x float> %326, i32 0
   %328 = fcmp olt float %327, 1.000000e+01
   %329 = xor i1 %328, true
-  br i1 %329, label %then236, label %ifmerge238
+  br i1 %329, label %then213, label %ifmerge215
 
-then236:                                          ; preds = %loop-header235
-  br label %loop-merge246
+then213:                                          ; preds = %loop-header212
+  br label %loop-merge222
 
-post-loop-break237:                               ; No predecessors!
+post-loop-break214:                               ; No predecessors!
   unreachable
 
-ifmerge238:                                       ; preds = %loop-header235
+ifmerge215:                                       ; preds = %loop-header212
   %330 = load <4 x float> addrspace(2)* @bigColor8, !gla.uniform !27
   %331 = load <4 x float>* %color
-  %color239 = fadd <4 x float> %331, %330
-  store <4 x float> %color239, <4 x float>* %color
+  %color216 = fadd <4 x float> %331, %330
+  store <4 x float> %color216, <4 x float>* %color
   %332 = load <4 x float>* %color
   %333 = extractelement <4 x float> %332, i32 2
   %334 = load float addrspace(2)* @d8, !gla.uniform !22
   %335 = fcmp olt float %333, %334
-  br i1 %335, label %then240, label %ifmerge244
+  br i1 %335, label %then217, label %ifmerge221
 
-then240:                                          ; preds = %ifmerge238
+then217:                                          ; preds = %ifmerge215
   %336 = load <4 x float>* %color
   %337 = extractelement <4 x float> %336, i32 3
   %338 = load float addrspace(2)* @d6, !gla.uniform !18
   %339 = fcmp olt float %337, %338
-  br i1 %339, label %then241, label %ifmerge243
+  br i1 %339, label %then218, label %ifmerge220
 
-then241:                                          ; preds = %then240
-  br label %loop-header235
+then218:                                          ; preds = %then217
+  br label %loop-header212
 
-post-loop-continue242:                            ; No predecessors!
+post-loop-continue219:                            ; No predecessors!
   unreachable
 
-ifmerge243:                                       ; preds = %then240
-  br label %ifmerge244
+ifmerge220:                                       ; preds = %then217
+  br label %ifmerge221
 
-ifmerge244:                                       ; preds = %ifmerge238, %ifmerge243
+ifmerge221:                                       ; preds = %ifmerge215, %ifmerge220
   %340 = load <4 x float> addrspace(2)* @bigColor8, !gla.uniform !27
   %341 = extractelement <4 x float> %340, i32 0
   %342 = load <4 x float>* %color
   %343 = extractelement <4 x float> %342, i32 1
   %344 = fadd float %343, %341
-  %345 = load <4 x float>* %color
-  %color245 = insertelement <4 x float> %345, float %344, i32 1
-  store <4 x float> %color245, <4 x float>* %color
-  br label %loop-header235
+  %345 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %344, float* %345
+  br label %loop-header212
 
-loop-merge246:                                    ; preds = %then236
+loop-merge222:                                    ; preds = %then213
   %346 = load <4 x float>* %color
-  %color247 = fadd <4 x float> %346, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color247, <4 x float>* %color
+  %color223 = fadd <4 x float> %346, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color223, <4 x float>* %color
   %gl_FragColor = load <4 x float>* %color
   store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor
-  br label %loop-header248
+  br label %loop-header224
 
-loop-header248:                                   ; preds = %ifmerge255, %loop-merge246
+loop-header224:                                   ; preds = %ifmerge231, %loop-merge222
   %347 = load <4 x float>* %color
   %348 = extractelement <4 x float> %347, i32 0
   %349 = load float addrspace(2)* @d14, !gla.uniform !28
   %350 = fcmp olt float %348, %349
   %351 = xor i1 %350, true
-  br i1 %351, label %then249, label %ifmerge251
+  br i1 %351, label %then225, label %ifmerge227
 
-then249:                                          ; preds = %loop-header248
-  br label %loop-merge256
+then225:                                          ; preds = %loop-header224
+  br label %loop-merge232
 
-post-loop-break250:                               ; No predecessors!
+post-loop-break226:                               ; No predecessors!
   unreachable
 
-ifmerge251:                                       ; preds = %loop-header248
+ifmerge227:                                       ; preds = %loop-header224
   %352 = load <4 x float>* %color
   %353 = extractelement <4 x float> %352, i32 1
   %354 = load float addrspace(2)* @d15, !gla.uniform !29
   %355 = fcmp olt float %353, %354
-  br i1 %355, label %then252, label %else253
+  br i1 %355, label %then228, label %else229
 
-then252:                                          ; preds = %ifmerge251
+then228:                                          ; preds = %ifmerge227
   br label %stage-epilogue
 
 post-return:                                      ; No predecessors!
   unreachable
 
-else253:                                          ; preds = %ifmerge251
+else229:                                          ; preds = %ifmerge227
   %356 = load <4 x float>* %color
-  %color254 = fadd <4 x float> %356, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color254, <4 x float>* %color
-  br label %ifmerge255
+  %color230 = fadd <4 x float> %356, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color230, <4 x float>* %color
+  br label %ifmerge231
 
-ifmerge255:                                       ; preds = %else253
-  br label %loop-header248
+ifmerge231:                                       ; preds = %else229
+  br label %loop-header224
 
-loop-merge256:                                    ; preds = %then249
+loop-merge232:                                    ; preds = %then225
   %357 = load <4 x float>* %color
-  %color257 = fadd <4 x float> %357, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color257, <4 x float>* %color
-  br label %loop-header258
+  %color233 = fadd <4 x float> %357, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color233, <4 x float>* %color
+  br label %loop-header234
 
-loop-header258:                                   ; preds = %ifmerge261, %loop-merge256
+loop-header234:                                   ; preds = %ifmerge237, %loop-merge232
   %358 = load <4 x float>* %color
   %359 = extractelement <4 x float> %358, i32 3
   %360 = load float addrspace(2)* @d16, !gla.uniform !30
   %361 = fcmp olt float %359, %360
   %362 = xor i1 %361, true
-  br i1 %362, label %then259, label %ifmerge261
+  br i1 %362, label %then235, label %ifmerge237
 
-then259:                                          ; preds = %loop-header258
-  br label %loop-merge263
+then235:                                          ; preds = %loop-header234
+  br label %loop-merge238
 
-post-loop-break260:                               ; No predecessors!
+post-loop-break236:                               ; No predecessors!
   unreachable
 
-ifmerge261:                                       ; preds = %loop-header258
+ifmerge237:                                       ; preds = %loop-header234
   %363 = load <4 x float>* %color
   %364 = extractelement <4 x float> %363, i32 3
   %365 = fadd float %364, 1.000000e+00
-  %366 = load <4 x float>* %color
-  %color262 = insertelement <4 x float> %366, float %365, i32 3
-  store <4 x float> %color262, <4 x float>* %color
-  br label %loop-header258
+  %366 = getelementptr <4 x float>* %color, i32 0, i32 3
+  store float %365, float* %366
+  br label %loop-header234
 
-loop-merge263:                                    ; preds = %then259
-  br label %loop-header264
+loop-merge238:                                    ; preds = %then235
+  br label %loop-header239
 
-loop-header264:                                   ; preds = %ifmerge271, %loop-merge263
+loop-header239:                                   ; preds = %ifmerge246, %loop-merge238
   %367 = load <4 x float>* %color
   %368 = extractelement <4 x float> %367, i32 3
   %369 = load float addrspace(2)* @d2, !gla.uniform !7
@@ -1197,118 +1172,118 @@ loop-header264:                                   ; preds = %ifmerge271, %loop-m
   %374 = fcmp olt float %372, %373
   %375 = and i1 %370, %374
   %376 = xor i1 %375, true
-  br i1 %376, label %then265, label %ifmerge267
+  br i1 %376, label %then240, label %ifmerge242
 
-then265:                                          ; preds = %loop-header264
-  br label %loop-merge272
+then240:                                          ; preds = %loop-header239
+  br label %loop-merge247
 
-post-loop-break266:                               ; No predecessors!
+post-loop-break241:                               ; No predecessors!
   unreachable
 
-ifmerge267:                                       ; preds = %loop-header264
+ifmerge242:                                       ; preds = %loop-header239
   %377 = load <4 x float> addrspace(2)* @bigColor1_2, !gla.uniform !9
   %378 = load <4 x float>* %color
-  %color268 = fadd <4 x float> %378, %377
-  store <4 x float> %color268, <4 x float>* %color
+  %color243 = fadd <4 x float> %378, %377
+  store <4 x float> %color243, <4 x float>* %color
   %379 = load <4 x float>* %color
   %380 = extractelement <4 x float> %379, i32 2
   %381 = load float addrspace(2)* @d3, !gla.uniform !8
   %382 = fcmp olt float %380, %381
-  br i1 %382, label %then269, label %ifmerge271
+  br i1 %382, label %then244, label %ifmerge246
 
-then269:                                          ; preds = %ifmerge267
+then244:                                          ; preds = %ifmerge242
   br label %stage-epilogue
 
-post-return270:                                   ; No predecessors!
+post-return245:                                   ; No predecessors!
   unreachable
 
-ifmerge271:                                       ; preds = %ifmerge267
-  br label %loop-header264
+ifmerge246:                                       ; preds = %ifmerge242
+  br label %loop-header239
 
-loop-merge272:                                    ; preds = %then265
-  br label %loop-header273
+loop-merge247:                                    ; preds = %then240
+  br label %loop-header248
 
-loop-header273:                                   ; preds = %loop-merge272
-  br label %loop-body274
+loop-header248:                                   ; preds = %loop-merge247
+  br label %loop-body249
 
-loop-body274:                                     ; preds = %loop-test279, %loop-header273
+loop-body249:                                     ; preds = %loop-test254, %loop-header248
   %383 = load <4 x float>* %color
   %384 = extractelement <4 x float> %383, i32 1
   %385 = load float addrspace(2)* @d18, !gla.uniform !31
   %386 = fcmp olt float %384, %385
-  br i1 %386, label %then275, label %ifmerge277
+  br i1 %386, label %then250, label %ifmerge252
 
-then275:                                          ; preds = %loop-body274
+then250:                                          ; preds = %loop-body249
   br label %stage-epilogue
 
-post-return276:                                   ; No predecessors!
+post-return251:                                   ; No predecessors!
   unreachable
 
-ifmerge277:                                       ; preds = %loop-body274
+ifmerge252:                                       ; preds = %loop-body249
   %387 = load <4 x float>* %color
-  %color278 = fadd <4 x float> %387, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color278, <4 x float>* %color
-  br label %loop-test279
+  %color253 = fadd <4 x float> %387, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color253, <4 x float>* %color
+  br label %loop-test254
 
-loop-test279:                                     ; preds = %ifmerge277
+loop-test254:                                     ; preds = %ifmerge252
   %388 = load <4 x float>* %color
   %389 = extractelement <4 x float> %388, i32 0
   %390 = load float addrspace(2)* @d17, !gla.uniform !32
   %391 = fcmp olt float %389, %390
-  br i1 %391, label %loop-body274, label %loop-merge280
+  br i1 %391, label %loop-body249, label %loop-merge255
 
-loop-merge280:                                    ; preds = %loop-test279
-  br label %loop-header281
+loop-merge255:                                    ; preds = %loop-test254
+  br label %loop-header256
 
-loop-header281:                                   ; preds = %ifmerge288, %loop-merge280
+loop-header256:                                   ; preds = %ifmerge263, %loop-merge255
   %392 = load <4 x float>* %color
   %393 = extractelement <4 x float> %392, i32 1
   %394 = load float addrspace(2)* @d16, !gla.uniform !30
   %395 = fcmp olt float %393, %394
   %396 = xor i1 %395, true
-  br i1 %396, label %then282, label %ifmerge284
+  br i1 %396, label %then257, label %ifmerge259
 
-then282:                                          ; preds = %loop-header281
-  br label %loop-merge289
+then257:                                          ; preds = %loop-header256
+  br label %loop-merge264
 
-post-loop-break283:                               ; No predecessors!
+post-loop-break258:                               ; No predecessors!
   unreachable
 
-ifmerge284:                                       ; preds = %loop-header281
+ifmerge259:                                       ; preds = %loop-header256
   %397 = load <4 x float>* %color
   %398 = extractelement <4 x float> %397, i32 3
   %399 = load float addrspace(2)* @d16, !gla.uniform !30
   %400 = fcmp olt float %398, %399
-  br i1 %400, label %then285, label %else286
+  br i1 %400, label %then260, label %else261
 
-then285:                                          ; preds = %ifmerge284
+then260:                                          ; preds = %ifmerge259
   call void @llvm.gla.discard()
   br label %stage-exit
 
 post-discard:                                     ; No predecessors!
   unreachable
 
-else286:                                          ; preds = %ifmerge284
+else261:                                          ; preds = %ifmerge259
   %401 = load <4 x float>* %color
-  %color287 = fadd <4 x float> %401, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color287, <4 x float>* %color
-  br label %ifmerge288
+  %color262 = fadd <4 x float> %401, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color262, <4 x float>* %color
+  br label %ifmerge263
 
-ifmerge288:                                       ; preds = %else286
-  br label %loop-header281
+ifmerge263:                                       ; preds = %else261
+  br label %loop-header256
 
-loop-merge289:                                    ; preds = %then282
+loop-merge264:                                    ; preds = %then257
   %402 = load <4 x float>* %color
-  %color290 = fadd <4 x float> %402, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color290, <4 x float>* %color
-  %gl_FragColor291 = load <4 x float>* %color
-  store <4 x float> %gl_FragColor291, <4 x float>* @gl_FragColor
+  %color265 = fadd <4 x float> %402, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color265, <4 x float>* %color
+  %gl_FragColor266 = load <4 x float>* %color
+  store <4 x float> %gl_FragColor266, <4 x float>* @gl_FragColor
   br label %stage-epilogue
 
-stage-epilogue:                                   ; preds = %loop-merge289, %then275, %then269, %then252
+stage-epilogue:                                   ; preds = %loop-merge264, %then250, %then244, %then228
   br label %stage-exit
 
-stage-exit:                                       ; preds = %stage-epilogue, %then285
+stage-exit:                                       ; preds = %stage-epilogue, %then260
   ret void
 }
 

--- a/test/baseResults/loopsArtificial.frag.out
+++ b/test/baseResults/loopsArtificial.frag.out
@@ -73,67 +73,63 @@ loop-body:                                        ; preds = %loop-test, %loop-he
   %3 = extractelement <4 x float> %2, i32 0
   %4 = load float addrspace(2)* @d4, !gla.uniform !5
   %5 = fcmp olt float %3, %4
-  br i1 %5, label %then, label %ifmerge6
+  br i1 %5, label %then, label %ifmerge4
 
 then:                                             ; preds = %loop-body
   %6 = load <4 x float>* %color
   %7 = extractelement <4 x float> %6, i32 2
   %8 = fadd float %7, 2.000000e+00
-  %9 = load <4 x float>* %color
-  %color3 = insertelement <4 x float> %9, float %8, i32 2
-  store <4 x float> %color3, <4 x float>* %color
+  %9 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %8, float* %9
   %10 = load <4 x float>* %color
   %11 = extractelement <4 x float> %10, i32 2
   %12 = load float addrspace(2)* @d4, !gla.uniform !5
   %13 = fcmp olt float %11, %12
-  br i1 %13, label %then4, label %ifmerge
+  br i1 %13, label %then3, label %ifmerge
 
-then4:                                            ; preds = %then
+then3:                                            ; preds = %then
   %14 = load <4 x float>* %color
   %15 = extractelement <4 x float> %14, i32 0
   %16 = fadd float %15, 1.000000e+00
-  %17 = load <4 x float>* %color
-  %color5 = insertelement <4 x float> %17, float %16, i32 0
-  store <4 x float> %color5, <4 x float>* %color
+  %17 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %16, float* %17
   br label %loop-test
 
 post-loop-continue:                               ; No predecessors!
   unreachable
 
 ifmerge:                                          ; preds = %then
-  br label %ifmerge6
+  br label %ifmerge4
 
-ifmerge6:                                         ; preds = %loop-body, %ifmerge
+ifmerge4:                                         ; preds = %loop-body, %ifmerge
   %18 = load <4 x float>* %color
   %19 = extractelement <4 x float> %18, i32 1
   %20 = load float addrspace(2)* @d4, !gla.uniform !5
   %21 = fcmp olt float %19, %20
-  br i1 %21, label %then7, label %else
+  br i1 %21, label %then5, label %else
 
-then7:                                            ; preds = %ifmerge6
+then5:                                            ; preds = %ifmerge4
   %22 = load float addrspace(2)* @d4, !gla.uniform !5
   %23 = load <4 x float>* %color
   %24 = extractelement <4 x float> %23, i32 1
   %25 = fadd float %24, %22
-  %26 = load <4 x float>* %color
-  %color8 = insertelement <4 x float> %26, float %25, i32 1
-  store <4 x float> %color8, <4 x float>* %color
-  br label %ifmerge10
+  %26 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %25, float* %26
+  br label %ifmerge6
 
-else:                                             ; preds = %ifmerge6
+else:                                             ; preds = %ifmerge4
   %27 = load float addrspace(2)* @d4, !gla.uniform !5
   %28 = load <4 x float>* %color
   %29 = extractelement <4 x float> %28, i32 0
   %30 = fadd float %29, %27
-  %31 = load <4 x float>* %color
-  %color9 = insertelement <4 x float> %31, float %30, i32 0
-  store <4 x float> %color9, <4 x float>* %color
-  br label %ifmerge10
+  %31 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %30, float* %31
+  br label %ifmerge6
 
-ifmerge10:                                        ; preds = %else, %then7
+ifmerge6:                                         ; preds = %else, %then5
   br label %loop-test
 
-loop-test:                                        ; preds = %ifmerge10, %then4
+loop-test:                                        ; preds = %ifmerge6, %then3
   %32 = load <4 x float>* %color
   %33 = extractelement <4 x float> %32, i32 2
   %34 = load float addrspace(2)* @d4, !gla.uniform !5
@@ -141,119 +137,115 @@ loop-test:                                        ; preds = %ifmerge10, %then4
   br i1 %35, label %loop-body, label %loop-merge
 
 loop-merge:                                       ; preds = %loop-test
-  br label %loop-header11
+  br label %loop-header7
 
-loop-header11:                                    ; preds = %ifmerge31, %then22, %loop-merge
+loop-header7:                                     ; preds = %ifmerge23, %then17, %loop-merge
   %36 = load <4 x float>* %color
   %37 = extractelement <4 x float> %36, i32 3
   %38 = load float addrspace(2)* @d13, !gla.uniform !6
   %39 = fcmp olt float %37, %38
   %40 = xor i1 %39, true
-  br i1 %40, label %then12, label %ifmerge13
+  br i1 %40, label %then8, label %ifmerge9
 
-then12:                                           ; preds = %loop-header11
-  br label %loop-merge32
+then8:                                            ; preds = %loop-header7
+  br label %loop-merge24
 
 post-loop-break:                                  ; No predecessors!
   unreachable
 
-ifmerge13:                                        ; preds = %loop-header11
+ifmerge9:                                         ; preds = %loop-header7
   %41 = load <4 x float>* %color
   %42 = extractelement <4 x float> %41, i32 2
   %43 = load float addrspace(2)* @d13, !gla.uniform !6
   %44 = fcmp olt float %42, %43
-  br i1 %44, label %then14, label %else16
+  br i1 %44, label %then10, label %else12
 
-then14:                                           ; preds = %ifmerge13
+then10:                                           ; preds = %ifmerge9
   %45 = load <4 x float>* %color
-  %color15 = fadd <4 x float> %45, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color15, <4 x float>* %color
-  br label %ifmerge18
+  %color11 = fadd <4 x float> %45, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color11, <4 x float>* %color
+  br label %ifmerge14
 
-else16:                                           ; preds = %ifmerge13
+else12:                                           ; preds = %ifmerge9
   %46 = load <4 x float>* %color
-  %color17 = fsub <4 x float> %46, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color17, <4 x float>* %color
-  br label %ifmerge18
+  %color13 = fsub <4 x float> %46, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color13, <4 x float>* %color
+  br label %ifmerge14
 
-ifmerge18:                                        ; preds = %else16, %then14
+ifmerge14:                                        ; preds = %else12, %then10
   %47 = load <4 x float> addrspace(2)* @bigColor4, !gla.uniform !3
   %48 = load <4 x float>* %color
-  %color19 = fadd <4 x float> %48, %47
-  store <4 x float> %color19, <4 x float>* %color
+  %color15 = fadd <4 x float> %48, %47
+  store <4 x float> %color15, <4 x float>* %color
   %49 = load <4 x float>* %color
   %50 = extractelement <4 x float> %49, i32 0
   %51 = load float addrspace(2)* @d4, !gla.uniform !5
   %52 = fcmp olt float %50, %51
-  br i1 %52, label %then20, label %ifmerge26
+  br i1 %52, label %then16, label %ifmerge20
 
-then20:                                           ; preds = %ifmerge18
+then16:                                           ; preds = %ifmerge14
   %53 = load <4 x float>* %color
   %54 = extractelement <4 x float> %53, i32 2
   %55 = fadd float %54, 2.000000e+00
-  %56 = load <4 x float>* %color
-  %color21 = insertelement <4 x float> %56, float %55, i32 2
-  store <4 x float> %color21, <4 x float>* %color
+  %56 = getelementptr <4 x float>* %color, i32 0, i32 2
+  store float %55, float* %56
   %57 = load <4 x float>* %color
   %58 = extractelement <4 x float> %57, i32 2
   %59 = load float addrspace(2)* @d4, !gla.uniform !5
   %60 = fcmp olt float %58, %59
-  br i1 %60, label %then22, label %ifmerge25
+  br i1 %60, label %then17, label %ifmerge19
 
-then22:                                           ; preds = %then20
+then17:                                           ; preds = %then16
   %61 = load <4 x float>* %color
   %62 = extractelement <4 x float> %61, i32 0
   %63 = fadd float %62, 1.000000e+00
-  %64 = load <4 x float>* %color
-  %color23 = insertelement <4 x float> %64, float %63, i32 0
-  store <4 x float> %color23, <4 x float>* %color
-  br label %loop-header11
+  %64 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %63, float* %64
+  br label %loop-header7
 
-post-loop-continue24:                             ; No predecessors!
+post-loop-continue18:                             ; No predecessors!
   unreachable
 
-ifmerge25:                                        ; preds = %then20
-  br label %ifmerge26
+ifmerge19:                                        ; preds = %then16
+  br label %ifmerge20
 
-ifmerge26:                                        ; preds = %ifmerge18, %ifmerge25
+ifmerge20:                                        ; preds = %ifmerge14, %ifmerge19
   %65 = load <4 x float>* %color
   %66 = extractelement <4 x float> %65, i32 1
   %67 = load float addrspace(2)* @d4, !gla.uniform !5
   %68 = fcmp olt float %66, %67
-  br i1 %68, label %then27, label %else29
+  br i1 %68, label %then21, label %else22
 
-then27:                                           ; preds = %ifmerge26
+then21:                                           ; preds = %ifmerge20
   %69 = load float addrspace(2)* @d4, !gla.uniform !5
   %70 = load <4 x float>* %color
   %71 = extractelement <4 x float> %70, i32 1
   %72 = fadd float %71, %69
-  %73 = load <4 x float>* %color
-  %color28 = insertelement <4 x float> %73, float %72, i32 1
-  store <4 x float> %color28, <4 x float>* %color
-  br label %ifmerge31
+  %73 = getelementptr <4 x float>* %color, i32 0, i32 1
+  store float %72, float* %73
+  br label %ifmerge23
 
-else29:                                           ; preds = %ifmerge26
+else22:                                           ; preds = %ifmerge20
   %74 = load float addrspace(2)* @d4, !gla.uniform !5
   %75 = load <4 x float>* %color
   %76 = extractelement <4 x float> %75, i32 0
   %77 = fadd float %76, %74
-  %78 = load <4 x float>* %color
-  %color30 = insertelement <4 x float> %78, float %77, i32 0
-  store <4 x float> %color30, <4 x float>* %color
-  br label %ifmerge31
+  %78 = getelementptr <4 x float>* %color, i32 0, i32 0
+  store float %77, float* %78
+  br label %ifmerge23
 
-ifmerge31:                                        ; preds = %else29, %then27
-  br label %loop-header11
+ifmerge23:                                        ; preds = %else22, %then21
+  br label %loop-header7
 
-loop-merge32:                                     ; preds = %then12
+loop-merge24:                                     ; preds = %then8
   %79 = load <4 x float>* %color
-  %color33 = fadd <4 x float> %79, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
-  store <4 x float> %color33, <4 x float>* %color
+  %color25 = fadd <4 x float> %79, <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+  store <4 x float> %color25, <4 x float>* %color
   %gl_FragColor = load <4 x float>* %color
   store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor
   br label %stage-epilogue
 
-stage-epilogue:                                   ; preds = %loop-merge32
+stage-epilogue:                                   ; preds = %loop-merge24
   br label %stage-exit
 
 stage-exit:                                       ; preds = %stage-epilogue

--- a/test/baseResults/parallel.out
+++ b/test/baseResults/parallel.out
@@ -3193,21 +3193,21 @@ mainBody:                                         ; preds = %entry
   %8 = extractelement <4 x float> %3, i32 2
   %9 = insertelement <3 x float> %7, float %8, i32 2
   %10 = fadd <3 x float> %9, %2
-  %11 = load <4 x float>* %texColor
-  %12 = extractelement <3 x float> %10, i32 0
-  %13 = insertelement <4 x float> %11, float %12, i32 0
-  %14 = extractelement <3 x float> %10, i32 1
-  %15 = insertelement <4 x float> %13, float %14, i32 1
-  %16 = extractelement <3 x float> %10, i32 2
-  %texColor2 = insertelement <4 x float> %15, float %16, i32 2
-  store <4 x float> %texColor2, <4 x float>* %texColor
+  %11 = extractelement <3 x float> %10, i32 0
+  %12 = getelementptr <4 x float>* %texColor, i32 0, i32 0
+  store float %11, float* %12
+  %13 = extractelement <3 x float> %10, i32 1
+  %14 = getelementptr <4 x float>* %texColor, i32 0, i32 1
+  store float %13, float* %14
+  %15 = extractelement <3 x float> %10, i32 2
+  %16 = getelementptr <4 x float>* %texColor, i32 0, i32 2
+  store float %15, float* %16
   %17 = load float addrspace(2)* getelementptr inbounds ([16 x float] addrspace(2)* @alpha, i32 0, i32 12), !gla.uniform !4
   %18 = load <4 x float>* %texColor
   %19 = extractelement <4 x float> %18, i32 3
   %20 = fadd float %19, %17
-  %21 = load <4 x float>* %texColor
-  %texColor3 = insertelement <4 x float> %21, float %20, i32 3
-  store <4 x float> %texColor3, <4 x float>* %texColor
+  %21 = getelementptr <4 x float>* %texColor, i32 0, i32 3
+  store float %20, float* %21
   %gl_FragColor = load <4 x float>* %texColor
   store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor
   br label %stage-epilogue
@@ -3298,169 +3298,166 @@ mainBody:                                         ; preds = %entry
   %11 = load <4 x float>* %v
   %12 = extractelement <4 x float> %11, i32 1
   %13 = fadd float %12, %v7
-  %14 = load <4 x float>* %v
-  %v8 = insertelement <4 x float> %14, float %13, i32 1
-  store <4 x float> %v8, <4 x float>* %v
+  %14 = getelementptr <4 x float>* %v, i32 0, i32 1
+  store float %13, float* %14
   %15 = load i32 addrspace(1)* @s3D, !gla.uniform !4
   %16 = load <3 x i32>* @ic3D
   %17 = load i32* @ic1D
-  %v9 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.v3i32.i32.i32(i32 3, i32 %15, i32 164, <3 x i32> %16, i32 %17, float undef, i32 undef)
+  %v8 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.v3i32.i32.i32(i32 3, i32 %15, i32 164, <3 x i32> %16, i32 %17, float undef, i32 undef)
   %18 = load <4 x float>* %v
-  %v10 = fadd <4 x float> %18, %v9
-  store <4 x float> %v10, <4 x float>* %v
+  %v9 = fadd <4 x float> %18, %v8
+  store <4 x float> %v9, <4 x float>* %v
   %19 = load i32 addrspace(1)* @s2D, !gla.uniform !1
   %20 = load <2 x i32>* @ic2D
-  %v11 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.v2i32.i32.v2i32(i32 2, i32 %19, i32 420, <2 x i32> %20, i32 4, float undef, <2 x i32> <i32 3, i32 3>)
+  %v10 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.v2i32.i32.v2i32(i32 2, i32 %19, i32 420, <2 x i32> %20, i32 4, float undef, <2 x i32> <i32 3, i32 3>)
   %21 = load <4 x float>* %v
-  %v12 = fadd <4 x float> %21, %v11
-  store <4 x float> %v12, <4 x float>* %v
+  %v11 = fadd <4 x float> %21, %v10
+  store <4 x float> %v11, <4 x float>* %v
   %22 = load i32 addrspace(1)* @s2DShadow, !gla.uniform !10
   %23 = load <3 x float>* @c3D
   %24 = load float* @c1D
-  %v13 = call float @llvm.gla.fTextureSampleLodRefZOffset.f32.v3f32.v2i32(i32 2, i32 %22, i32 396, <3 x float> %23, float %24, float undef, <2 x i32> <i32 3, i32 3>)
+  %v12 = call float @llvm.gla.fTextureSampleLodRefZOffset.f32.v3f32.v2i32(i32 2, i32 %22, i32 396, <3 x float> %23, float %24, float undef, <2 x i32> <i32 3, i32 3>)
   %25 = load <4 x float>* %v
   %26 = extractelement <4 x float> %25, i32 1
-  %27 = fadd float %26, %v13
-  %28 = load <4 x float>* %v
-  %v14 = insertelement <4 x float> %28, float %27, i32 1
-  store <4 x float> %v14, <4 x float>* %v
+  %27 = fadd float %26, %v12
+  %28 = getelementptr <4 x float>* %v, i32 0, i32 1
+  store float %27, float* %28
   %29 = load i32 addrspace(1)* @s2D, !gla.uniform !1
   %30 = load <3 x float>* @c3D
   %31 = load float* @c1D
-  %v15 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffset.v4f32.v3f32.v2i32(i32 2, i32 %29, i32 389, <3 x float> %30, float %31, float undef, <2 x i32> <i32 3, i32 3>)
+  %v13 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffset.v4f32.v3f32.v2i32(i32 2, i32 %29, i32 389, <3 x float> %30, float %31, float undef, <2 x i32> <i32 3, i32 3>)
   %32 = load <4 x float>* %v
-  %v16 = fadd <4 x float> %32, %v15
-  store <4 x float> %v16, <4 x float>* %v
+  %v14 = fadd <4 x float> %32, %v13
+  store <4 x float> %v14, <4 x float>* %v
   %33 = load i32 addrspace(1)* @sCube, !gla.uniform !13
   %34 = load <3 x float>* @c3D
   %35 = load <3 x float>* @c3D
   %36 = load <3 x float>* @c3D
-  %v17 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffsetGrad.v4f32.v3f32.i32.v3f32.v3f32(i32 4, i32 %33, i32 0, <3 x float> %34, float undef, float undef, i32 undef, <3 x float> %35, <3 x float> %36)
+  %v15 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffsetGrad.v4f32.v3f32.i32.v3f32.v3f32(i32 4, i32 %33, i32 0, <3 x float> %34, float undef, float undef, i32 undef, <3 x float> %35, <3 x float> %36)
   %37 = load <4 x float>* %v
-  %v18 = fadd <4 x float> %37, %v17
-  store <4 x float> %v18, <4 x float>* %v
+  %v16 = fadd <4 x float> %37, %v15
+  store <4 x float> %v16, <4 x float>* %v
   %38 = load i32 addrspace(1)* @s2DArrayShadow, !gla.uniform !16
   %39 = load <4 x float>* @c4D
   %40 = load <2 x float>* @c2D
   %41 = load <2 x float>* @c2D
-  %v19 = call float @llvm.gla.fTextureSampleLodRefZOffsetGrad.f32.v4f32.v2i32.v2f32.v2f32(i32 2, i32 %38, i32 280, <4 x float> %39, float undef, float undef, <2 x i32> <i32 3, i32 3>, <2 x float> %40, <2 x float> %41)
+  %v17 = call float @llvm.gla.fTextureSampleLodRefZOffsetGrad.f32.v4f32.v2i32.v2f32.v2f32(i32 2, i32 %38, i32 280, <4 x float> %39, float undef, float undef, <2 x i32> <i32 3, i32 3>, <2 x float> %40, <2 x float> %41)
   %42 = load <4 x float>* %v
   %43 = extractelement <4 x float> %42, i32 0
-  %44 = fadd float %43, %v19
-  %45 = load <4 x float>* %v
-  %v20 = insertelement <4 x float> %45, float %44, i32 0
-  store <4 x float> %v20, <4 x float>* %v
+  %44 = fadd float %43, %v17
+  %45 = getelementptr <4 x float>* %v, i32 0, i32 0
+  store float %44, float* %45
   %46 = load i32 addrspace(1)* @s3D, !gla.uniform !4
   %47 = load <4 x float>* @c4D
   %48 = load <3 x float>* @c3D
   %49 = load <3 x float>* @c3D
-  %v21 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffsetGrad.v4f32.v4f32.i32.v3f32.v3f32(i32 3, i32 %46, i32 1, <4 x float> %47, float undef, float undef, i32 undef, <3 x float> %48, <3 x float> %49)
+  %v18 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffsetGrad.v4f32.v4f32.i32.v3f32.v3f32(i32 3, i32 %46, i32 1, <4 x float> %47, float undef, float undef, i32 undef, <3 x float> %48, <3 x float> %49)
   %50 = load <4 x float>* %v
-  %v22 = fadd <4 x float> %50, %v21
-  store <4 x float> %v22, <4 x float>* %v
+  %v19 = fadd <4 x float> %50, %v18
+  store <4 x float> %v19, <4 x float>* %v
   %51 = load i32 addrspace(1)* @s2D, !gla.uniform !1
   %52 = load <3 x float>* @c3D
   %53 = load <2 x float>* @c2D
   %54 = load <2 x float>* @c2D
-  %v23 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffsetGrad.v4f32.v3f32.v2i32.v2f32.v2f32(i32 2, i32 %51, i32 257, <3 x float> %52, float undef, float undef, <2 x i32> <i32 3, i32 3>, <2 x float> %53, <2 x float> %54)
+  %v20 = call <4 x float> @llvm.gla.fTextureSampleLodRefZOffsetGrad.v4f32.v3f32.v2i32.v2f32.v2f32(i32 2, i32 %51, i32 257, <3 x float> %52, float undef, float undef, <2 x i32> <i32 3, i32 3>, <2 x float> %53, <2 x float> %54)
   %55 = load <4 x float>* %v
-  %v24 = fadd <4 x float> %55, %v23
-  store <4 x float> %v24, <4 x float>* %v
+  %v21 = fadd <4 x float> %55, %v20
+  store <4 x float> %v21, <4 x float>* %v
   %56 = load i32 addrspace(1)* @is2D, !gla.uniform !19
   %57 = load <2 x float>* @c2D
-  %iv25 = call <4 x i32> @llvm.gla.textureSample.v4i32.v2f32(i32 2, i32 %56, i32 0, <2 x float> %57)
-  store <4 x i32> %iv25, <4 x i32>* %iv
+  %iv22 = call <4 x i32> @llvm.gla.textureSample.v4i32.v2f32(i32 2, i32 %56, i32 0, <2 x float> %57)
+  store <4 x i32> %iv22, <4 x i32>* %iv
   %58 = load <4 x i32>* %iv
   %59 = sitofp <4 x i32> %58 to <4 x float>
   %60 = load <4 x float>* %v
-  %v26 = fadd <4 x float> %60, %59
-  store <4 x float> %v26, <4 x float>* %v
+  %v23 = fadd <4 x float> %60, %59
+  store <4 x float> %v23, <4 x float>* %v
   %61 = load i32 addrspace(1)* @is2D, !gla.uniform !19
   %62 = load <4 x float>* @c4D
-  %iv27 = call <4 x i32> @llvm.gla.textureSampleLodRefZOffset.v4i32.v4f32.v2i32(i32 2, i32 %61, i32 257, <4 x float> %62, float undef, float undef, <2 x i32> <i32 3, i32 3>)
-  store <4 x i32> %iv27, <4 x i32>* %iv
+  %iv24 = call <4 x i32> @llvm.gla.textureSampleLodRefZOffset.v4i32.v4f32.v2i32(i32 2, i32 %61, i32 257, <4 x float> %62, float undef, float undef, <2 x i32> <i32 3, i32 3>)
+  store <4 x i32> %iv24, <4 x i32>* %iv
   %63 = load <4 x i32>* %iv
   %64 = sitofp <4 x i32> %63 to <4 x float>
   %65 = load <4 x float>* %v
-  %v28 = fadd <4 x float> %65, %64
-  store <4 x float> %v28, <4 x float>* %v
+  %v25 = fadd <4 x float> %65, %64
+  store <4 x float> %v25, <4 x float>* %v
   %66 = load i32 addrspace(1)* @is2D, !gla.uniform !19
   %67 = load <3 x float>* @c3D
   %68 = load float* @c1D
-  %iv29 = call <4 x i32> @llvm.gla.textureSampleLodRefZ.v4i32.v3f32(i32 2, i32 %66, i32 133, <3 x float> %67, float %68, float undef)
-  store <4 x i32> %iv29, <4 x i32>* %iv
+  %iv26 = call <4 x i32> @llvm.gla.textureSampleLodRefZ.v4i32.v3f32(i32 2, i32 %66, i32 133, <3 x float> %67, float %68, float undef)
+  store <4 x i32> %iv26, <4 x i32>* %iv
   %69 = load <4 x i32>* %iv
   %70 = sitofp <4 x i32> %69 to <4 x float>
   %71 = load <4 x float>* %v
-  %v30 = fadd <4 x float> %71, %70
-  store <4 x float> %v30, <4 x float>* %v
+  %v27 = fadd <4 x float> %71, %70
+  store <4 x float> %v27, <4 x float>* %v
   %72 = load i32 addrspace(1)* @is2D, !gla.uniform !19
   %73 = load <3 x float>* @c3D
   %74 = load <2 x float>* @c2D
   %75 = load <2 x float>* @c2D
-  %iv31 = call <4 x i32> @llvm.gla.textureSampleLodRefZOffsetGrad.v4i32.v3f32.i32.v2f32.v2f32(i32 2, i32 %72, i32 1, <3 x float> %73, float undef, float undef, i32 undef, <2 x float> %74, <2 x float> %75)
-  store <4 x i32> %iv31, <4 x i32>* %iv
+  %iv28 = call <4 x i32> @llvm.gla.textureSampleLodRefZOffsetGrad.v4i32.v3f32.i32.v2f32.v2f32(i32 2, i32 %72, i32 1, <3 x float> %73, float undef, float undef, i32 undef, <2 x float> %74, <2 x float> %75)
+  store <4 x i32> %iv28, <4 x i32>* %iv
   %76 = load <4 x i32>* %iv
   %77 = sitofp <4 x i32> %76 to <4 x float>
   %78 = load <4 x float>* %v
-  %v32 = fadd <4 x float> %78, %77
-  store <4 x float> %v32, <4 x float>* %v
+  %v29 = fadd <4 x float> %78, %77
+  store <4 x float> %v29, <4 x float>* %v
   %79 = load i32 addrspace(1)* @is3D, !gla.uniform !22
   %80 = load <3 x float>* @c3D
-  %iv33 = call <4 x i32> @llvm.gla.textureSampleLodRefZ.v4i32.v3f32(i32 3, i32 %79, i32 130, <3 x float> %80, float 0x4010CCCCC0000000, float undef)
-  store <4 x i32> %iv33, <4 x i32>* %iv
+  %iv30 = call <4 x i32> @llvm.gla.textureSampleLodRefZ.v4i32.v3f32(i32 3, i32 %79, i32 130, <3 x float> %80, float 0x4010CCCCC0000000, float undef)
+  store <4 x i32> %iv30, <4 x i32>* %iv
   %81 = load <4 x i32>* %iv
   %82 = sitofp <4 x i32> %81 to <4 x float>
   %83 = load <4 x float>* %v
-  %v34 = fadd <4 x float> %83, %82
-  store <4 x float> %v34, <4 x float>* %v
+  %v31 = fadd <4 x float> %83, %82
+  store <4 x float> %v31, <4 x float>* %v
   %84 = load i32 addrspace(1)* @isCube, !gla.uniform !25
   %85 = load <3 x float>* @c3D
   %86 = load float* @c1D
-  %iv35 = call <4 x i32> @llvm.gla.textureSampleLodRefZ.v4i32.v3f32(i32 4, i32 %84, i32 132, <3 x float> %85, float %86, float undef)
-  store <4 x i32> %iv35, <4 x i32>* %iv
+  %iv32 = call <4 x i32> @llvm.gla.textureSampleLodRefZ.v4i32.v3f32(i32 4, i32 %84, i32 132, <3 x float> %85, float %86, float undef)
+  store <4 x i32> %iv32, <4 x i32>* %iv
   %87 = load <4 x i32>* %iv
   %88 = sitofp <4 x i32> %87 to <4 x float>
   %89 = load <4 x float>* %v
-  %v36 = fadd <4 x float> %89, %88
-  store <4 x float> %v36, <4 x float>* %v
+  %v33 = fadd <4 x float> %89, %88
+  store <4 x float> %v33, <4 x float>* %v
   %90 = load i32 addrspace(1)* @is2DArray, !gla.uniform !28
   %91 = load <3 x i32>* @ic3D
   %92 = load i32* @ic1D
-  %iv37 = call <4 x i32> @llvm.gla.texelFetchOffset.v4i32.v3i32.i32.i32(i32 2, i32 %90, i32 180, <3 x i32> %91, i32 %92, float undef, i32 undef)
-  store <4 x i32> %iv37, <4 x i32>* %iv
+  %iv34 = call <4 x i32> @llvm.gla.texelFetchOffset.v4i32.v3i32.i32.i32(i32 2, i32 %90, i32 180, <3 x i32> %91, i32 %92, float undef, i32 undef)
+  store <4 x i32> %iv34, <4 x i32>* %iv
   %93 = load <4 x i32>* %iv
   %94 = sitofp <4 x i32> %93 to <4 x float>
   %95 = load <4 x float>* %v
-  %v38 = fadd <4 x float> %95, %94
-  store <4 x float> %v38, <4 x float>* %v
+  %v35 = fadd <4 x float> %95, %94
+  store <4 x float> %v35, <4 x float>* %v
   %96 = load i32 addrspace(1)* @is2Dms, !gla.uniform !31
   %97 = load <2 x i32>* @ic2D
   %98 = load i32* @ic1D
-  %iv39 = call <4 x i32> @llvm.gla.texelFetchOffset.v4i32.v2i32.i32.i32(i32 6, i32 %96, i32 672, <2 x i32> %97, i32 %98, float undef, i32 undef)
+  %iv36 = call <4 x i32> @llvm.gla.texelFetchOffset.v4i32.v2i32.i32.i32(i32 6, i32 %96, i32 672, <2 x i32> %97, i32 %98, float undef, i32 undef)
   %99 = load <4 x i32>* %iv
-  %iv40 = add <4 x i32> %99, %iv39
-  store <4 x i32> %iv40, <4 x i32>* %iv
+  %iv37 = add <4 x i32> %99, %iv36
+  store <4 x i32> %iv37, <4 x i32>* %iv
   %100 = load <4 x i32>* %iv
   %101 = sitofp <4 x i32> %100 to <4 x float>
   %102 = load <4 x float>* %v
-  %v41 = fadd <4 x float> %102, %101
-  store <4 x float> %v41, <4 x float>* %v
+  %v38 = fadd <4 x float> %102, %101
+  store <4 x float> %v38, <4 x float>* %v
   %103 = load i32 addrspace(1)* @sb, !gla.uniform !34
   %104 = load i32* @ic1D
-  %v42 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.i32.i32.i32(i32 0, i32 %103, i32 32, i32 %104, i32 undef, float undef, i32 undef)
+  %v39 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.i32.i32.i32(i32 0, i32 %103, i32 32, i32 %104, i32 undef, float undef, i32 undef)
   %105 = load <4 x float>* %v
-  %v43 = fadd <4 x float> %105, %v42
-  store <4 x float> %v43, <4 x float>* %v
+  %v40 = fadd <4 x float> %105, %v39
+  store <4 x float> %v40, <4 x float>* %v
   %106 = load i32 addrspace(1)* @sr, !gla.uniform !37
   %107 = load <2 x i32>* @ic2D
-  %v44 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.v2i32.i32.i32(i32 5, i32 %106, i32 32, <2 x i32> %107, i32 undef, float undef, i32 undef)
+  %v41 = call <4 x float> @llvm.gla.fTexelFetchOffset.v4f32.v2i32.i32.i32(i32 5, i32 %106, i32 32, <2 x i32> %107, i32 undef, float undef, i32 undef)
   %108 = load <4 x float>* %v
-  %v45 = fadd <4 x float> %108, %v44
-  store <4 x float> %v45, <4 x float>* %v
+  %v42 = fadd <4 x float> %108, %v41
+  store <4 x float> %v42, <4 x float>* %v
   %109 = load i32 addrspace(1)* @sCubeShadow, !gla.uniform !40
-  %iv246 = call <2 x i32> @llvm.gla.queryTextureSize.v2i32(i32 4, i32 %109, i32 2)
-  store <2 x i32> %iv246, <2 x i32>* %iv2
+  %iv243 = call <2 x i32> @llvm.gla.queryTextureSize.v2i32(i32 4, i32 %109, i32 2)
+  store <2 x i32> %iv243, <2 x i32>* %iv2
   %110 = load <4 x float>* %v
   %111 = load <2 x i32>* %iv2
   %112 = sitofp <2 x i32> %111 to <2 x float>
@@ -3471,8 +3468,8 @@ mainBody:                                         ; preds = %entry
   %117 = insertelement <4 x float> %115, float %116, i32 1
   %118 = insertelement <4 x float> %117, float 0.000000e+00, i32 2
   %119 = insertelement <4 x float> %118, float 0.000000e+00, i32 3
-  %FragData47 = fadd <4 x float> %110, %119
-  store <4 x float> %FragData47, <4 x float>* @FragData
+  %FragData44 = fadd <4 x float> %110, %119
+  store <4 x float> %FragData44, <4 x float>* @FragData
   br label %stage-epilogue
 
 stage-epilogue:                                   ; preds = %mainBody

--- a/test/baseResults/prepost.frag.out
+++ b/test/baseResults/prepost.frag.out
@@ -87,21 +87,17 @@ mainBody:                                         ; preds = %entry
   %30 = load <4 x float>* %v
   %31 = extractelement <4 x float> %30, i32 2
   %32 = fsub float %31, 1.000000e+00
-  %33 = load <4 x float>* %v
-  %v15 = insertelement <4 x float> %33, float %32, i32 2
-  store <4 x float> %v15, <4 x float>* %v
-  %34 = load <4 x float>* %v
-  %v16 = insertelement <4 x float> %34, float %31, i32 1
-  store <4 x float> %v16, <4 x float>* %v
+  %33 = getelementptr <4 x float>* %v, i32 0, i32 2
+  store float %32, float* %33
+  %34 = getelementptr <4 x float>* %v, i32 0, i32 1
+  store float %31, float* %34
   %35 = load <4 x float>* %v
   %36 = extractelement <4 x float> %35, i32 3
   %37 = fsub float %36, 1.000000e+00
-  %38 = load <4 x float>* %v
-  %v17 = insertelement <4 x float> %38, float %37, i32 3
-  store <4 x float> %v17, <4 x float>* %v
-  %39 = load <4 x float>* %v
-  %v18 = insertelement <4 x float> %39, float %37, i32 0
-  store <4 x float> %v18, <4 x float>* %v
+  %38 = getelementptr <4 x float>* %v, i32 0, i32 3
+  store float %37, float* %38
+  %39 = getelementptr <4 x float>* %v, i32 0, i32 0
+  store float %37, float* %39
   %40 = load float* %z
   %41 = load <4 x float>* %v
   %42 = insertelement <4 x float> undef, float %40, i32 0

--- a/test/baseResults/swizzle.frag.out
+++ b/test/baseResults/swizzle.frag.out
@@ -34,20 +34,18 @@ mainBody:                                         ; preds = %entry
   %w_flow5 = load <4 x float> addrspace(2)* @u, !gla.uniform !1
   store <4 x float> %w_flow5, <4 x float>* %w_flow
   %0 = load float* %blendscale
-  %1 = load <4 x float>* %w_reorder
-  %w_reorder6 = insertelement <4 x float> %1, float %0, i32 2
-  store <4 x float> %w_reorder6, <4 x float>* %w_reorder
+  %1 = getelementptr <4 x float>* %w_reorder, i32 0, i32 2
+  store float %0, float* %1
   %2 = load <2 x float>* @t
-  %3 = load <4 x float>* %w
-  %4 = extractelement <2 x float> %2, i32 0
-  %5 = insertelement <4 x float> %3, float %4, i32 3
-  %6 = extractelement <2 x float> %2, i32 1
-  %w7 = insertelement <4 x float> %5, float %6, i32 1
-  store <4 x float> %w7, <4 x float>* %w
+  %3 = extractelement <2 x float> %2, i32 0
+  %4 = getelementptr <4 x float>* %w, i32 0, i32 3
+  store float %3, float* %4
+  %5 = extractelement <2 x float> %2, i32 1
+  %6 = getelementptr <4 x float>* %w, i32 0, i32 1
+  store float %5, float* %6
   %7 = load float* %blendscale
-  %8 = load <4 x float>* %w_reorder
-  %w_reorder8 = insertelement <4 x float> %8, float %7, i32 0
-  store <4 x float> %w_reorder8, <4 x float>* %w_reorder
+  %8 = getelementptr <4 x float>* %w_reorder, i32 0, i32 0
+  store float %7, float* %8
   %9 = load <4 x float> addrspace(2)* @u, !gla.uniform !1
   %10 = extractelement <4 x float> %9, i32 2
   %11 = insertelement <4 x float> undef, float %10, i32 0
@@ -56,58 +54,55 @@ mainBody:                                         ; preds = %entry
   %14 = extractelement <4 x float> %9, i32 0
   %15 = insertelement <4 x float> %13, float %14, i32 2
   %16 = extractelement <4 x float> %9, i32 1
-  %w29 = insertelement <4 x float> %15, float %16, i32 3
-  store <4 x float> %w29, <4 x float>* %w2
+  %w26 = insertelement <4 x float> %15, float %16, i32 3
+  store <4 x float> %w26, <4 x float>* %w2
   %17 = load float* %blendscale
-  %18 = load <4 x float>* %w_reorder
-  %w_reorder10 = insertelement <4 x float> %18, float %17, i32 1
-  store <4 x float> %w_reorder10, <4 x float>* %w_reorder
+  %18 = getelementptr <4 x float>* %w_reorder, i32 0, i32 1
+  store float %17, float* %18
   %19 = load <4 x float>* %w2
   %20 = extractelement <4 x float> %19, i32 0
   %21 = insertelement <2 x float> undef, float %20, i32 0
   %22 = extractelement <4 x float> %19, i32 2
   %23 = insertelement <2 x float> %21, float %22, i32 1
-  %24 = load <4 x float>* %w_dep
-  %25 = extractelement <2 x float> %23, i32 0
-  %26 = insertelement <4 x float> %24, float %25, i32 0
-  %27 = extractelement <2 x float> %23, i32 1
-  %w_dep11 = insertelement <4 x float> %26, float %27, i32 1
-  store <4 x float> %w_dep11, <4 x float>* %w_dep
+  %24 = extractelement <2 x float> %23, i32 0
+  %25 = getelementptr <4 x float>* %w_dep, i32 0, i32 0
+  store float %24, float* %25
+  %26 = extractelement <2 x float> %23, i32 1
+  %27 = getelementptr <4 x float>* %w_dep, i32 0, i32 1
+  store float %26, float* %27
   %28 = load <2 x float>* @t
-  %29 = load <4 x float>* %w_dep
-  %30 = extractelement <2 x float> %28, i32 0
-  %31 = insertelement <4 x float> %29, float %30, i32 2
-  %32 = extractelement <2 x float> %28, i32 1
-  %w_dep12 = insertelement <4 x float> %31, float %32, i32 3
-  store <4 x float> %w_dep12, <4 x float>* %w_dep
+  %29 = extractelement <2 x float> %28, i32 0
+  %30 = getelementptr <4 x float>* %w_dep, i32 0, i32 2
+  store float %29, float* %30
+  %31 = extractelement <2 x float> %28, i32 1
+  %32 = getelementptr <4 x float>* %w_dep, i32 0, i32 3
+  store float %31, float* %32
   %33 = load <4 x float> addrspace(2)* @u, !gla.uniform !1
   %34 = extractelement <4 x float> %33, i32 2
   %35 = insertelement <2 x float> undef, float %34, i32 0
   %36 = extractelement <4 x float> %33, i32 3
   %37 = insertelement <2 x float> %35, float %36, i32 1
-  %38 = load <4 x float>* %w_undef
-  %39 = extractelement <2 x float> %37, i32 0
-  %40 = insertelement <4 x float> %38, float %39, i32 0
-  %41 = extractelement <2 x float> %37, i32 1
-  %w_undef13 = insertelement <4 x float> %40, float %41, i32 1
-  store <4 x float> %w_undef13, <4 x float>* %w_undef
+  %38 = extractelement <2 x float> %37, i32 0
+  %39 = getelementptr <4 x float>* %w_undef, i32 0, i32 0
+  store float %38, float* %39
+  %40 = extractelement <2 x float> %37, i32 1
+  %41 = getelementptr <4 x float>* %w_undef, i32 0, i32 1
+  store float %40, float* %41
   %42 = load i1 addrspace(2)* @p, !gla.uniform !3
   br i1 %42, label %then, label %else
 
 then:                                             ; preds = %mainBody
   %43 = load <2 x float>* @t
   %44 = extractelement <2 x float> %43, i32 0
-  %45 = load <4 x float>* %w_flow
-  %w_flow14 = insertelement <4 x float> %45, float %44, i32 0
-  store <4 x float> %w_flow14, <4 x float>* %w_flow
+  %45 = getelementptr <4 x float>* %w_flow, i32 0, i32 0
+  store float %44, float* %45
   br label %ifmerge
 
 else:                                             ; preds = %mainBody
   %46 = load <2 x float>* @t
   %47 = extractelement <2 x float> %46, i32 1
-  %48 = load <4 x float>* %w_flow
-  %w_flow15 = insertelement <4 x float> %48, float %47, i32 0
-  store <4 x float> %w_flow15, <4 x float>* %w_flow
+  %48 = getelementptr <4 x float>* %w_flow, i32 0, i32 0
+  store float %47, float* %48
   br label %ifmerge
 
 ifmerge:                                          ; preds = %else, %then
@@ -122,43 +117,41 @@ ifmerge:                                          ; preds = %else, %then
   %57 = fmul <4 x float> %55, %56
   %gl_FragColor = call <4 x float> @llvm.gla.fMix.v4f32.v4f32.v4f32.v4f32(<4 x float> %49, <4 x float> %50, <4 x float> %57)
   store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor
-  %c16 = load <2 x float>* @t
-  store <2 x float> %c16, <2 x float>* %c
+  %c7 = load <2 x float>* @t
+  store <2 x float> %c7, <2 x float>* %c
   store <4 x float> <float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 1.000000e+00>, <4 x float>* %rep
   %58 = load <2 x float>* %c
   %59 = extractelement <2 x float> %58, i32 0
   %60 = fcmp olt float %59, 0.000000e+00
-  br i1 %60, label %then17, label %ifmerge19
+  br i1 %60, label %then8, label %ifmerge9
 
-then17:                                           ; preds = %ifmerge
+then8:                                            ; preds = %ifmerge
   %61 = load <2 x float>* %c
   %62 = extractelement <2 x float> %61, i32 0
   %63 = fmul float %62, -1.000000e+00
-  %64 = load <2 x float>* %c
-  %c18 = insertelement <2 x float> %64, float %63, i32 0
-  store <2 x float> %c18, <2 x float>* %c
-  br label %ifmerge19
+  %64 = getelementptr <2 x float>* %c, i32 0, i32 0
+  store float %63, float* %64
+  br label %ifmerge9
 
-ifmerge19:                                        ; preds = %ifmerge, %then17
+ifmerge9:                                         ; preds = %ifmerge, %then8
   %65 = load <2 x float>* %c
   %66 = extractelement <2 x float> %65, i32 0
   %67 = fcmp ole float %66, 1.000000e+00
-  br i1 %67, label %then20, label %ifmerge22
+  br i1 %67, label %then10, label %ifmerge11
 
-then20:                                           ; preds = %ifmerge19
-  %68 = load <4 x float>* %rep
-  %rep21 = insertelement <4 x float> %68, float 0x400B333340000000, i32 0
-  store <4 x float> %rep21, <4 x float>* %rep
-  br label %ifmerge22
+then10:                                           ; preds = %ifmerge9
+  %68 = getelementptr <4 x float>* %rep, i32 0, i32 0
+  store float 0x400B333340000000, float* %68
+  br label %ifmerge11
 
-ifmerge22:                                        ; preds = %ifmerge19, %then20
+ifmerge11:                                        ; preds = %ifmerge9, %then10
   %69 = load <4 x float>* %rep
   %70 = load <4 x float>* @gl_FragColor
-  %gl_FragColor23 = fadd <4 x float> %70, %69
-  store <4 x float> %gl_FragColor23, <4 x float>* @gl_FragColor
+  %gl_FragColor12 = fadd <4 x float> %70, %69
+  store <4 x float> %gl_FragColor12, <4 x float>* @gl_FragColor
   br label %stage-epilogue
 
-stage-epilogue:                                   ; preds = %ifmerge22
+stage-epilogue:                                   ; preds = %ifmerge11
   br label %stage-exit
 
 stage-exit:                                       ; preds = %stage-epilogue

--- a/test/baseResults/varyingArray.frag.out
+++ b/test/baseResults/varyingArray.frag.out
@@ -32,9 +32,8 @@ mainBody:                                         ; preds = %entry
   %texColor3 = fadd <4 x float> %10, %9
   store <4 x float> %texColor3, <4 x float>* %texColor
   %11 = load float* @alpha
-  %12 = load <4 x float>* %texColor
-  %texColor4 = insertelement <4 x float> %12, float %11, i32 3
-  store <4 x float> %texColor4, <4 x float>* %texColor
+  %12 = getelementptr <4 x float>* %texColor, i32 0, i32 3
+  store float %11, float* %12
   %13 = load <4 x float>* getelementptr inbounds ([3 x <4 x float>]* @foo, i32 0, i32 1)
   %14 = load <4 x float>* getelementptr inbounds ([6 x <4 x float>]* @gl_TexCoord, i32 0, i32 0)
   %15 = fadd <4 x float> %13, %14

--- a/test/baseResults/varyingArrayIndirect.frag.out
+++ b/test/baseResults/varyingArrayIndirect.frag.out
@@ -40,9 +40,8 @@ mainBody:                                         ; preds = %entry
   %texColor3 = fadd <4 x float> %16, %15
   store <4 x float> %texColor3, <4 x float>* %texColor
   %17 = load float* @alpha
-  %18 = load <4 x float>* %texColor
-  %texColor4 = insertelement <4 x float> %18, float %17, i32 3
-  store <4 x float> %texColor4, <4 x float>* %texColor
+  %18 = getelementptr <4 x float>* %texColor, i32 0, i32 3
+  store float %17, float* %18
   %19 = load <4 x float>* getelementptr inbounds ([6 x <4 x float>]* @gl_TexCoord, i32 0, i32 0)
   %20 = load i32 addrspace(2)* @b, !gla.uniform !4
   %21 = getelementptr [6 x <4 x float>]* @gl_TexCoord, i32 0, i32 %20

--- a/test/baseResults/voidFunction.frag.out
+++ b/test/baseResults/voidFunction.frag.out
@@ -23,9 +23,8 @@ mainBody:                                         ; preds = %entry
   %1 = load <4 x float>* %outColor
   %2 = extractelement <4 x float> %1, i32 0
   %3 = fadd float %2, %0
-  %4 = load <4 x float>* %outColor
-  %outColor2 = insertelement <4 x float> %4, float %3, i32 0
-  store <4 x float> %outColor2, <4 x float>* %outColor
+  %4 = getelementptr <4 x float>* %outColor, i32 0, i32 0
+  store float %3, float* %4
   %gl_FragColor = load <4 x float>* %outColor
   store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor
   br label %stage-epilogue


### PR DESCRIPTION
Previously Stores were done at vector granularity but these were
problematic for parallel threads storing into same vector.