### PR TITLE
add uniform metadata for atomic memory intrinsic calls

### DIFF
--- a/Core/TopBuilder.cpp
+++ b/Core/TopBuilder.cpp
@@ -2379,7 +2379,7 @@ llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Int
 }
 
 // Comments in header
-llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Intrinsic::ID intrinsicID, llvm::Value* operand0, llvm::Value* operand1, const char* name)
+llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Intrinsic::ID intrinsicID, llvm::Value* operand0, llvm::Value* operand1, const char* name, llvm::MDNode* md)
 {
     llvm::Function* intrinsicName = 0;
 
@@ -2447,10 +2447,13 @@ llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Int
 
     setInstructionPrecision(instr, precision);
 
+    if (md)
+        instr->setMetadata(gla::UniformMdName, md);
+
     return instr;
 }
 
-llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Intrinsic::ID intrinsicID, llvm::Value* operand0, llvm::Value* operand1, llvm::Value* operand2, const char* name)
+llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Intrinsic::ID intrinsicID, llvm::Value* operand0, llvm::Value* operand1, llvm::Value* operand2, const char* name, llvm::MDNode* md)
 {
     llvm::Function* intrinsicName;
 
@@ -2485,6 +2488,9 @@ llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Int
     else
         instr = builder.CreateCall3(intrinsicName, operand0, operand1, operand2);
     setInstructionPrecision(instr, precision);
+
+    if (md)
+        instr->setMetadata(gla::UniformMdName, md);
 
     return instr;
 }

--- a/Core/TopBuilder.h
+++ b/Core/TopBuilder.h
@@ -148,11 +148,17 @@ public:
     // clear accessChain
     void clearAccessChain();
 
-    // store metadata in the access chain for future tagging of the load/store instruction
+    // store metadata in the access chain for future tagging of load/store/atomic instruction
     void setAccessChainMetadata(const char* mdk, llvm::MDNode* md)    
     { 
         accessChain.metadataKind = mdk;
         accessChain.mdNode = md; 
+    }
+
+    // retrieve metadata from the access chain for tagging of load/store/atomic instruction
+    llvm::MDNode* getAccessChainMetadata()    
+    { 
+        return accessChain.mdNode;
     }
 
     // say whether or not to evaluate a chain right to left (false means left to right)
@@ -399,8 +405,8 @@ public:
     llvm::Value* createIntrinsicCall(llvm::Intrinsic::ID);
     llvm::Value* createIntrinsicCall(EMdPrecision, llvm::Intrinsic::ID);
     llvm::Value* createIntrinsicCall(EMdPrecision, llvm::Intrinsic::ID, llvm::Value*, const char* name = 0);
-    llvm::Value* createIntrinsicCall(EMdPrecision, llvm::Intrinsic::ID, llvm::Value*, llvm::Value*, const char* name = 0);
-    llvm::Value* createIntrinsicCall(EMdPrecision, llvm::Intrinsic::ID, llvm::Value*, llvm::Value*, llvm::Value*, const char* name = 0);
+    llvm::Value* createIntrinsicCall(EMdPrecision, llvm::Intrinsic::ID, llvm::Value*, llvm::Value*, const char* name = 0, llvm::MDNode* md = 0);
+    llvm::Value* createIntrinsicCall(EMdPrecision, llvm::Intrinsic::ID, llvm::Value*, llvm::Value*, llvm::Value*, const char* name = 0, llvm::MDNode* md = 0);
     llvm::Value* createIntrinsicCall(EMdPrecision, llvm::Intrinsic::ID, llvm::Value*, llvm::Value*, llvm::Value*, llvm::Value*, const char* name = 0);
     llvm::Value* createRecip(EMdPrecision, llvm::Value*);
 

--- a/test/baseResults/atomic.comp.out
+++ b/test/baseResults/atomic.comp.out
@@ -76,8 +76,8 @@ entry:
   %3 = load i32 addrspace(2)* @value, !gla.uniform !3
   %origu8 = call i32 @llvm.gla.atomicCompExchange.p4i32(i32 addrspace(4)* @atomu, i32 10, i32 %3), !gla.precision !15
   store i32 %origu8, i32* %origu
-  %misc2a = call i32 @llvm.gla.atomicAdd.p3i32(i32 addrspace(3)* getelementptr inbounds (%bname addrspace(3)* @binst, i32 0, i32 1), i32 1), !gla.precision !15
-  %misc2a9 = call i32 @llvm.gla.atomicXor.p3i32(i32 addrspace(3)* getelementptr inbounds (%bname addrspace(3)* @binst, i32 0, i32 0, i32 1), i32 5), !gla.precision !15
+  %misc2a = call i32 @llvm.gla.atomicAdd.p3i32(i32 addrspace(3)* getelementptr inbounds (%bname addrspace(3)* @binst, i32 0, i32 1), i32 1), !gla.precision !15, !gla.uniform !5
+  %misc2a9 = call i32 @llvm.gla.atomicXor.p3i32(i32 addrspace(3)* getelementptr inbounds (%bname addrspace(3)* @binst, i32 0, i32 0, i32 1), i32 5), !gla.precision !15, !gla.uniform !5
   ret void
 }
 


### PR DESCRIPTION
the metadata corresponds to the argument that is operated on atomically.