### PR TITLE
Pass interpolant arg to InterpolateAt* as lvalue in TopIR

### DIFF
--- a/Backends/GLSL/BottomToGLSL.cpp
+++ b/Backends/GLSL/BottomToGLSL.cpp
@@ -4379,7 +4379,10 @@ void gla::GlslTarget::emitGlaValueDeclaration(const llvm::Value* value, const ch
 
     const llvm::Constant* constant = llvm::dyn_cast<llvm::Constant>(value);
     if (constant) {
-        emitNamelessConstDeclaration(value, constant);
+        if (llvm::isa<llvm::PointerType>(value->getType()))
+            mapPointerExpression(value);
+        else
+            emitNamelessConstDeclaration(value, constant);
 
         return;
     }

--- a/Core/LLVM/llvm-3.6.2/include/llvm/IR/IntrinsicsLunarGLASSTop.td
+++ b/Core/LLVM/llvm-3.6.2/include/llvm/IR/IntrinsicsLunarGLASSTop.td
@@ -256,9 +256,9 @@ let TargetPrefix = "gla" in {
   def int_gla_fDFdy : Intrinsic<[llvm_anyfloat_ty], [llvm_anyfloat_ty], [IntrNoMem]>;
   def int_gla_fFilterWidth : Intrinsic<[llvm_anyfloat_ty], [llvm_anyfloat_ty], [IntrNoMem]>;
   def int_gla_fFixedTransform : Intrinsic<[llvm_anyfloat_ty], [llvm_anyfloat_ty, llvm_anyfloat_ty], [IntrNoMem]>;
-  def int_gla_interpolateAtCentroid : Intrinsic<[llvm_anyfloat_ty], [llvm_anyfloat_ty],                [IntrNoMem]>;
-  def int_gla_interpolateAtSample   : Intrinsic<[llvm_anyfloat_ty], [llvm_anyfloat_ty, llvm_i32_ty],   [IntrNoMem]>;
-  def int_gla_interpolateAtOffset   : Intrinsic<[llvm_anyfloat_ty], [llvm_anyfloat_ty, llvm_v2f32_ty], [IntrNoMem]>;
+  def int_gla_interpolateAtCentroid : Intrinsic<[llvm_anyfloat_ty], [llvm_anyptr_ty],                [IntrReadArgMem]>;
+  def int_gla_interpolateAtSample   : Intrinsic<[llvm_anyfloat_ty], [llvm_anyptr_ty, llvm_i32_ty],   [IntrReadArgMem]>;
+  def int_gla_interpolateAtOffset   : Intrinsic<[llvm_anyfloat_ty], [llvm_anyptr_ty, llvm_v2f32_ty], [IntrReadArgMem]>;
 }
 
 // Comparison

--- a/Core/TopBuilder.cpp
+++ b/Core/TopBuilder.cpp
@@ -2358,6 +2358,10 @@ llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Int
         intrinsicName = getIntrinsic(intrinsicID);
         break;
 
+    case llvm::Intrinsic::gla_interpolateAtCentroid:
+        intrinsicName = getIntrinsic(intrinsicID,  operand->getType()->getContainedType(0), operand->getType());
+        break;
+
     default:
         // Unary intrinsics that have operand and dest with same flexible type
         intrinsicName = getIntrinsic(intrinsicID,  operand->getType(), operand->getType());
@@ -2418,7 +2422,7 @@ llvm::Value* Builder::createIntrinsicCall(gla::EMdPrecision precision, llvm::Int
     // the return type matches arg0.
     case llvm::Intrinsic::gla_interpolateAtSample:
     case llvm::Intrinsic::gla_interpolateAtOffset:
-        intrinsicName = getIntrinsic(intrinsicID, operand0->getType(), operand0->getType());
+        intrinsicName = getIntrinsic(intrinsicID, operand0->getType()->getContainedType(0), operand0->getType());
         break;
 
     // These all take two operands and return a struct with two members,

--- a/test/baseResults/aep.frag.out
+++ b/test/baseResults/aep.frag.out
@@ -124,64 +124,58 @@ define internal fastcc <3 x float> @"interp("() #0 {
 entry:
   %res3 = alloca <3 x float>
   %res = alloca float
-  %0 = load float* @scalarIn
-  %res1 = call float @llvm.gla.interpolateAtCentroid.f32.f32(float %0), !gla.precision !31
+  %res1 = call float @llvm.gla.interpolateAtCentroid.f32.p0f32(float* @scalarIn), !gla.precision !31
   store float %res1, float* %res
-  %1 = load <3 x float>* @sampInArray
-  %res32 = call <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.v3f32(<3 x float> %1), !gla.precision !31
+  %res32 = call <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.p0v3f32(<3 x float>* @sampInArray), !gla.precision !31
   store <3 x float> %res32, <3 x float>* %res3
-  %2 = load <3 x float>* @sampInArray
-  %res33 = call <3 x float> @llvm.gla.interpolateAtSample.v3f32.v3f32(<3 x float> %2, i32 0), !gla.precision !31
-  %3 = load <3 x float>* %res3
-  %res34 = fadd <3 x float> %3, %res33, !gla.precision !31
+  %res33 = call <3 x float> @llvm.gla.interpolateAtSample.v3f32.p0v3f32(<3 x float>* @sampInArray, i32 0), !gla.precision !31
+  %0 = load <3 x float>* %res3
+  %res34 = fadd <3 x float> %0, %res33, !gla.precision !31
   store <3 x float> %res34, <3 x float>* %res3
-  %4 = load float* @scalarIn
-  %res5 = call float @llvm.gla.interpolateAtSample.f32.f32(float %4, i32 1), !gla.precision !31
-  %5 = load float* %res
-  %res6 = fadd float %5, %res5, !gla.precision !31
+  %res5 = call float @llvm.gla.interpolateAtSample.f32.p0f32(float* @scalarIn, i32 1), !gla.precision !31
+  %1 = load float* %res
+  %res6 = fadd float %1, %res5, !gla.precision !31
   store float %res6, float* %res
-  %6 = load <3 x float>* @sampInArray
-  %res37 = call <3 x float> @llvm.gla.interpolateAtOffset.v3f32.v3f32(<3 x float> %6, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
-  %7 = load <3 x float>* %res3
-  %res38 = fadd <3 x float> %7, %res37, !gla.precision !31
+  %res37 = call <3 x float> @llvm.gla.interpolateAtOffset.v3f32.p0v3f32(<3 x float>* @sampInArray, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
+  %2 = load <3 x float>* %res3
+  %res38 = fadd <3 x float> %2, %res37, !gla.precision !31
   store <3 x float> %res38, <3 x float>* %res3
-  %8 = load float* @scalarIn
-  %res9 = call float @llvm.gla.interpolateAtOffset.f32.f32(float %8, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
-  %9 = load float* %res
-  %res10 = fadd float %9, %res9, !gla.precision !31
+  %res9 = call float @llvm.gla.interpolateAtOffset.f32.p0f32(float* @scalarIn, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
+  %3 = load float* %res
+  %res10 = fadd float %3, %res9, !gla.precision !31
   store float %res10, float* %res
-  %10 = load float* %res
-  %11 = load <3 x float>* %res3
-  %12 = insertelement <3 x float> undef, float %10, i32 0, !gla.precision !31
-  %13 = insertelement <3 x float> %12, float %10, i32 1, !gla.precision !31
-  %14 = insertelement <3 x float> %13, float %10, i32 2, !gla.precision !31
-  %15 = fmul <3 x float> %14, %11, !gla.precision !31
-  ret <3 x float> %15
+  %4 = load float* %res
+  %5 = load <3 x float>* %res3
+  %6 = insertelement <3 x float> undef, float %4, i32 0, !gla.precision !31
+  %7 = insertelement <3 x float> %6, float %4, i32 1, !gla.precision !31
+  %8 = insertelement <3 x float> %7, float %4, i32 2, !gla.precision !31
+  %9 = fmul <3 x float> %8, %5, !gla.precision !31
+  ret <3 x float> %9
 
 post-return:                                      ; No predecessors!
   unreachable
 }
 
-; Function Attrs: nounwind readnone
-declare float @llvm.gla.interpolateAtCentroid.f32.f32(float) #1
+; Function Attrs: nounwind readonly
+declare float @llvm.gla.interpolateAtCentroid.f32.p0f32(float*) #1
 
-; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.v3f32(<3 x float>) #1
+; Function Attrs: nounwind readonly
+declare <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.p0v3f32(<3 x float>*) #1
 
-; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.interpolateAtSample.v3f32.v3f32(<3 x float>, i32) #1
+; Function Attrs: nounwind readonly
+declare <3 x float> @llvm.gla.interpolateAtSample.v3f32.p0v3f32(<3 x float>*, i32) #1
 
-; Function Attrs: nounwind readnone
-declare float @llvm.gla.interpolateAtSample.f32.f32(float, i32) #1
+; Function Attrs: nounwind readonly
+declare float @llvm.gla.interpolateAtSample.f32.p0f32(float*, i32) #1
 
-; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.interpolateAtOffset.v3f32.v3f32(<3 x float>, <2 x float>) #1
+; Function Attrs: nounwind readonly
+declare <3 x float> @llvm.gla.interpolateAtOffset.v3f32.p0v3f32(<3 x float>*, <2 x float>) #1
 
-; Function Attrs: nounwind readnone
-declare float @llvm.gla.interpolateAtOffset.f32.f32(float, <2 x float>) #1
+; Function Attrs: nounwind readonly
+declare float @llvm.gla.interpolateAtOffset.f32.p0f32(float*, <2 x float>) #1
 
 attributes #0 = { alwaysinline }
-attributes #1 = { nounwind readnone }
+attributes #1 = { nounwind readonly }
 
 !gla.blendEquations = !{!0}
 !gla.entrypoint = !{!1}
@@ -277,32 +271,30 @@ entry:
   %9 = extractelement <2 x float> %7, i32 1
   %gla_constGEP6 = getelementptr <4 x float>* @color, i32 0, i32 1
   store float %9, float* %gla_constGEP6
-  %10 = load float* @scalarIn
-  %res1.i = call float @llvm.gla.interpolateAtCentroid.f32.f32(float %10), !gla.precision !31
-  %11 = load <3 x float>* @sampInArray
-  %res32.i = call <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.v3f32(<3 x float> %11), !gla.precision !31
-  %res33.i = call <3 x float> @llvm.gla.interpolateAtSample.v3f32.v3f32(<3 x float> %11, i32 0), !gla.precision !31
+  %res1.i = call float @llvm.gla.interpolateAtCentroid.f32.p0f32(float* @scalarIn), !gla.precision !31
+  %res32.i = call <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.p0v3f32(<3 x float>* @sampInArray), !gla.precision !31
+  %res33.i = call <3 x float> @llvm.gla.interpolateAtSample.v3f32.p0v3f32(<3 x float>* @sampInArray, i32 0), !gla.precision !31
   %res34.i = fadd <3 x float> %res32.i, %res33.i, !gla.precision !31
-  %res5.i = call float @llvm.gla.interpolateAtSample.f32.f32(float %10, i32 1), !gla.precision !31
+  %res5.i = call float @llvm.gla.interpolateAtSample.f32.p0f32(float* @scalarIn, i32 1), !gla.precision !31
   %res6.i = fadd float %res1.i, %res5.i, !gla.precision !31
-  %res37.i = call <3 x float> @llvm.gla.interpolateAtOffset.v3f32.v3f32(<3 x float> %11, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
+  %res37.i = call <3 x float> @llvm.gla.interpolateAtOffset.v3f32.p0v3f32(<3 x float>* @sampInArray, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
   %res38.i = fadd <3 x float> %res34.i, %res37.i, !gla.precision !31
-  %res9.i = call float @llvm.gla.interpolateAtOffset.f32.f32(float %10, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
+  %res9.i = call float @llvm.gla.interpolateAtOffset.f32.p0f32(float* @scalarIn, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>), !gla.precision !31
   %res10.i = fadd float %res6.i, %res9.i, !gla.precision !31
-  %12 = call <3 x float> @llvm.gla.fSwizzle.v3f32.f32.v3i32(float %res10.i, <3 x i32> zeroinitializer)
-  %13 = fmul <3 x float> %res38.i, %12, !gla.precision !31
-  %14 = load <4 x float>* @color
-  %15 = call <3 x float> @llvm.gla.fSwizzle.v3f32.v4f32.v3i32(<4 x float> %14, <3 x i32> <i32 0, i32 1, i32 2>)
-  %16 = fadd <3 x float> %15, %13, !gla.precision !31
-  %17 = extractelement <3 x float> %16, i32 0
+  %10 = call <3 x float> @llvm.gla.fSwizzle.v3f32.f32.v3i32(float %res10.i, <3 x i32> zeroinitializer)
+  %11 = fmul <3 x float> %res38.i, %10, !gla.precision !31
+  %12 = load <4 x float>* @color
+  %13 = call <3 x float> @llvm.gla.fSwizzle.v3f32.v4f32.v3i32(<4 x float> %12, <3 x i32> <i32 0, i32 1, i32 2>)
+  %14 = fadd <3 x float> %13, %11, !gla.precision !31
+  %15 = extractelement <3 x float> %14, i32 0
   %gla_constGEP7 = getelementptr <4 x float>* @color, i32 0, i32 0
-  store float %17, float* %gla_constGEP7
-  %18 = extractelement <3 x float> %16, i32 1
+  store float %15, float* %gla_constGEP7
+  %16 = extractelement <3 x float> %14, i32 1
   %gla_constGEP8 = getelementptr <4 x float>* @color, i32 0, i32 1
-  store float %18, float* %gla_constGEP8
-  %19 = extractelement <3 x float> %16, i32 2
+  store float %16, float* %gla_constGEP8
+  %17 = extractelement <3 x float> %14, i32 2
   %gla_constGEP9 = getelementptr <4 x float>* @color, i32 0, i32 2
-  store float %19, float* %gla_constGEP9
+  store float %17, float* %gla_constGEP9
   br label %stage-epilogue
 
 stage-epilogue:                                   ; preds = %entry
@@ -312,37 +304,38 @@ stage-exit:                                       ; preds = %stage-epilogue
   ret void
 }
 
-; Function Attrs: nounwind readnone
-declare float @llvm.gla.interpolateAtCentroid.f32.f32(float) #0
+; Function Attrs: nounwind readonly
+declare float @llvm.gla.interpolateAtCentroid.f32.p0f32(float*) #0
+
+; Function Attrs: nounwind readonly
+declare <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.p0v3f32(<3 x float>*) #0
+
+; Function Attrs: nounwind readonly
+declare <3 x float> @llvm.gla.interpolateAtSample.v3f32.p0v3f32(<3 x float>*, i32) #0
+
+; Function Attrs: nounwind readonly
+declare float @llvm.gla.interpolateAtSample.f32.p0f32(float*, i32) #0
+
+; Function Attrs: nounwind readonly
+declare <3 x float> @llvm.gla.interpolateAtOffset.v3f32.p0v3f32(<3 x float>*, <2 x float>) #0
+
+; Function Attrs: nounwind readonly
+declare float @llvm.gla.interpolateAtOffset.f32.p0f32(float*, <2 x float>) #0
 
 ; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.interpolateAtCentroid.v3f32.v3f32(<3 x float>) #0
+declare <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float, <4 x i32>) #1
 
 ; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.interpolateAtSample.v3f32.v3f32(<3 x float>, i32) #0
+declare <2 x float> @llvm.gla.fSwizzle.v2f32.v4f32.v2i32(<4 x float>, <2 x i32>) #1
 
 ; Function Attrs: nounwind readnone
-declare float @llvm.gla.interpolateAtSample.f32.f32(float, i32) #0
+declare <3 x float> @llvm.gla.fSwizzle.v3f32.f32.v3i32(float, <3 x i32>) #1
 
 ; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.interpolateAtOffset.v3f32.v3f32(<3 x float>, <2 x float>) #0
+declare <3 x float> @llvm.gla.fSwizzle.v3f32.v4f32.v3i32(<4 x float>, <3 x i32>) #1
 
-; Function Attrs: nounwind readnone
-declare float @llvm.gla.interpolateAtOffset.f32.f32(float, <2 x float>) #0
-
-; Function Attrs: nounwind readnone
-declare <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float, <4 x i32>) #0
-
-; Function Attrs: nounwind readnone
-declare <2 x float> @llvm.gla.fSwizzle.v2f32.v4f32.v2i32(<4 x float>, <2 x i32>) #0
-
-; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.fSwizzle.v3f32.f32.v3i32(float, <3 x i32>) #0
-
-; Function Attrs: nounwind readnone
-declare <3 x float> @llvm.gla.fSwizzle.v3f32.v4f32.v3i32(<4 x float>, <3 x i32>) #0
-
-attributes #0 = { nounwind readnone }
+attributes #0 = { nounwind readonly }
+attributes #1 = { nounwind readnone }
 
 !gla.blendEquations = !{!0}
 !gla.entrypoint = !{!1}

--- a/test/baseResults/flowControl.frag.out
+++ b/test/baseResults/flowControl.frag.out
@@ -123,4 +123,22 @@ stage-exit:                                       ; preds = %stage-epilogue
 !9 = !{!"smallColor", i32 12, <4 x float>* @smallColor_typeProxy, !6, !""}
 !10 = !{!"gl_FragColor", i32 7, <4 x float>* @gl_FragColor_typeProxy, !11, !""}
 !11 = !{i32 0, i32 0, i32 1026, null, i32 0, i32 43, i32 -1, i32 0, i32 -1}
-LunarGOO: /home/greg/ss/LunarGLASS.36/Backends/GLSL/BottomToGLSL.cpp:4563: void gla::GlslTarget::emitConstantInitializer(std::ostringstream&, const llvm::Constant*, llvm::Type*): Assertion `0 && "Constant type in Bottom IR"' failed.
+#version 120
+// LunarGOO output
+uniform vec4 otherColor;
+uniform float d;
+uniform vec4 bigColor;
+uniform vec4 smallColor;
+varying vec4 BaseColor;
+varying float c;
+
+void main()
+{
+	bool H_wll4g81 = c > d;
+	vec4 _L = H_wll4g81 ? bigColor : smallColor;
+	vec4 color = BaseColor + _L;
+	vec4 Ll_FragColor1 = color * otherColor;
+	gl_FragColor = Ll_FragColor1;
+	
+}
+

--- a/test/baseResults/structAssignment.frag.out
+++ b/test/baseResults/structAssignment.frag.out
@@ -186,4 +186,39 @@ attributes #0 = { nounwind readnone }
 !29 = !{i32 0, i32 0, i32 1024, null, i32 0, i32 43, i32 -1, i32 0, i32 -1}
 !30 = !{!"coord", i32 1, <2 x float>* @coord_typeProxy, !31, !""}
 !31 = !{i32 0, i32 0, i32 1025, null, i32 1, i32 0, i32 -1, i32 0, i32 -1}
-LunarGOO: /home/greg/ss/LunarGLASS.36/Backends/GLSL/BottomToGLSL.cpp:4563: void gla::GlslTarget::emitConstantInitializer(std::ostringstream&, const llvm::Constant*, llvm::Type*): Assertion `0 && "Constant type in Bottom IR"' failed.
+#version 130
+// LunarGOO output
+struct lunarStruct1 {
+	int i;
+	float f;
+};
+struct lunarStruct2 {
+	int i;
+	float f;
+	lunarStruct1 s1_1;
+};
+struct lunarStruct3 {
+	lunarStruct2 s2_1;
+	int i;
+	float f;
+	lunarStruct1 s1_1;
+};
+uniform lunarStruct3 foo3;
+uniform lunarStruct2 foo2;
+uniform sampler2D sampler;
+uniform lunarStruct1 foo;
+in vec2 coord;
+const int C_0 = 0;
+
+void main()
+{
+	lunarStruct2 locals;
+	bool H_27n3qy = foo3.s2_1.i > C_0;
+	lunarStruct2 storemerge = H_27n3qy ? foo3.s2_1 : foo2;
+	vec4 H_v4jh0a = vec4(storemerge.s1_1.f);
+	vec4 Ll_FragColor1 = texture(sampler, coord);
+	vec4 Ll_FragColor2 = H_v4jh0a * Ll_FragColor1;
+	gl_FragColor = Ll_FragColor2;
+	
+}
+


### PR DESCRIPTION
Previously the interpolant was loaded and passed as an rvalue.
This created the potential that the interpolant argument could
map to more than one input variable in the presence of control
flow.

The GLSL backend also now handles pointer constants.
