### PR TITLE
Remove early returns from non-main function conditionals

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     Passes/Transforms/CanonicalizeInsts.cpp
     Passes/Transforms/CoalesceInserts.cpp
     Passes/Transforms/DecomposeInsts.cpp
+    Passes/Transforms/EarlyReturnElim.cpp
     Passes/Transforms/FlattenConditionalAssignments.cpp
     Passes/Transforms/GatherInsts.cpp
     Passes/Transforms/IntrinsicCombine.cpp

--- a/Core/Passes/InitializePasses.h
+++ b/Core/Passes/InitializePasses.h
@@ -58,6 +58,8 @@ namespace llvm {
 
     void initializeCoalesceInsertsPass(PassRegistry&);
 
+    void initializeEarlyReturnElimPass(PassRegistry&);
+
     void initializeFlattenCondAssnPass(PassRegistry&);
 
     void initializeIdentifyConditionalsPass(PassRegistry&);

--- a/Core/Passes/Passes.h
+++ b/Core/Passes/Passes.h
@@ -60,6 +60,10 @@ namespace gla_llvm {
     // Coalesce insert/extracts into multiInserts
     FunctionPass* createCoalesceInsertsPass();
 
+    // Transform early returns into equivalent control flow in non-main 
+    // functions.
+    FunctionPass* createEarlyReturnElimPass();
+
     // Flatten conditional assignments into select instructions. Currently only
     // simplifies instructions, deletes dead code, and then removes empty
     // conditionals

--- a/Core/Passes/Transforms/EarlyReturnElim.cpp
+++ b/Core/Passes/Transforms/EarlyReturnElim.cpp
@@ -1,0 +1,321 @@
+//===- EarlyReturnElim.cpp - Canonicalize the CFG for LunarGLASS ----------===//
+//
+// LunarGLASS: An Open Modular Shader Compiler Architecture
+// Copyright (C) 2010-2014 LunarG, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+//     Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+// 
+//     Redistributions in binary form must reproduce the above
+//     copyright notice, this list of conditions and the following
+//     disclaimer in the documentation and/or other materials provided
+//     with the distribution.
+// 
+//     Neither the name of LunarG Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+//===----------------------------------------------------------------------===//
+//
+// Author:  Greg Fischer, LunarG
+//
+//===----------------------------------------------------------------------===//
+//
+// Eliminate Early Returns for LunarGLASS. Specifically, convert
+// early returns into equivalent control flow in non-main functions.
+// This is done so that the control flow in non-main functions is reducible. 
+// This allows the control flow to be converted into structured 
+// control flow constructs. It also makes subsequent analysis and 
+// optimizations more efficient and effective.
+//
+// Assumes that basic blocks are ordered such that if B1 dominates B2,
+// B1 precedes B2, and if B2 post-dominates B1, B1 precedes B2. Also,
+// if B1 dominates B2, it also dominates all blocks between B1 and B2, and
+// if B2 post-dominates B1, it post-dominates all blocks between B2 and B1.
+//
+// TODO: Handle early returns in loops and functions with switches
+//
+//===----------------------------------------------------------------------===//
+
+#pragma warning(push, 1)
+#include "llvm/Pass.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/Dominators.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Support/CFG.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/Local.h"
+#pragma warning(pop)
+
+#include "Passes/PassSupport.h"
+#include "Passes/Analysis/IdentifyStructures.h"
+#include "Passes/Util/BasicBlockUtil.h"
+#include "Passes/Util/FunctionUtil.h"
+#include "Passes/Util/InstructionUtil.h"
+
+#include "Exceptions.h"
+
+using namespace llvm;
+using namespace gla_llvm;
+
+namespace  {
+    class EarlyReturnElim : public FunctionPass {
+    public:
+        // Standard pass stuff
+        static char ID;
+
+        EarlyReturnElim() : FunctionPass(ID)
+        {
+            initializeEarlyReturnElimPass(*PassRegistry::getPassRegistry());
+        }
+
+        virtual bool runOnFunction(Function&)  __attribute__((optimize(0)));
+        void print(raw_ostream&, const Module* = 0) const;
+        virtual void getAnalysisUsage(AnalysisUsage&) const;
+
+    protected:
+        LoopInfo* loopInfo;
+        DominatorTree* domTree;
+        IdentifyStructures* idStructs;
+
+        BasicBlock* exit;
+        BasicBlock* epilogue;
+
+    };
+} // end namespace
+
+bool EarlyReturnElim::runOnFunction(Function& F)
+{
+    if (IsMain(F)) 
+        return false;
+
+    bool changed = false;
+
+    loopInfo  = &getAnalysis<LoopInfo>();
+    domTree   = &getAnalysis<DominatorTree>();
+    idStructs = &getAnalysis<IdentifyStructures>();
+
+    BasicBlock *finalbb = NULL;
+    AllocaInst *retBool = 0;
+    AllocaInst *retVal = 0;
+
+    // Process blocks in reverse order
+    for (Function::BasicBlockListType::reverse_iterator bbI = F.getBasicBlockList().rbegin(), e = F.getBasicBlockList().rend(); bbI != e; /* empty */ ) {
+
+        BasicBlock *obb = &*bbI++;
+        ReturnInst *retInst = dyn_cast<ReturnInst>(obb->getTerminator());
+        if (! retInst)
+	    continue;
+
+        // Remember final return block, but do not process it unless early
+        // returns are found
+        if (! finalbb) {
+            finalbb = obb;
+            continue;
+        }
+
+        // TODO: For now, skip returns inside loops
+        Loop *L = loopInfo->getLoopFor(obb);
+        if (L)
+            continue;
+        
+        changed = true;
+
+        // Early return found. If not already done, create temps on stack to 
+        // remember return state and value
+        if (! retBool) {
+            BasicBlock::iterator insertPt = F.getEntryBlock().begin();
+            retBool = new AllocaInst(Type::getInt1Ty(F.getContext()), 0, 
+                                     "earlyretbool",
+                                     insertPt);
+            (void) new StoreInst(ConstantInt::getFalse(F.getContext()), 
+                                     retBool, insertPt);
+
+            if (retInst->getNumOperands() > 0) {
+                Value *retOpnd = retInst->getOperand(0);
+                retVal = new AllocaInst(retOpnd->getType(), 0, 
+                                         "earlyretval",
+                                         insertPt);
+
+                // Split final block into two: store of return value in first
+                // block and actual return in second.
+                Instruction *finalRet = finalbb->getTerminator();
+                Value *finalRetOpnd = finalRet->getOperand(0);
+                BasicBlock *nbb = finalbb->splitBasicBlock(
+                                   finalRet,
+                                   "return.split");
+                (void) new StoreInst(finalRetOpnd, retVal, finalbb->getTerminator());
+                LoadInst *loadRetVal = new LoadInst(retVal, 
+                                                    "earlyretval.load", 
+                                                    false, finalRet);
+                (void) ReturnInst::Create(F.getContext(), loadRetVal, finalRet);
+                finalRet->eraseFromParent();
+                finalbb = nbb;
+            } else {
+                // split return into its own block
+                finalbb = finalbb->splitBasicBlock(finalbb->getTerminator(),
+                                   "return.split");
+            }
+        }
+        BasicBlock *pbb = obb;
+
+        // If the early return is in a loop, set the early return variables, 
+        // turn the exit into a break and process the loop's break block. Add
+        // conditional break on early return boolean and continue to process 
+        // break blocks while inside a loop.
+        // TODO: add code to handle early return inside loop
+        if (L) {
+            gla::UnsupportedFunctionality("early return in loop");
+        }
+
+        // Process blocks until we have iterated out of all containing
+        // conditionals and are at final block.
+        while (pbb != finalbb) {
+            BasicBlock *mbb = 0;
+            if (pbb == obb) {
+                // process original return block if not processed yet
+                // set early return variables and branch past controlling
+                // conditional's exit block or branch to final return block
+                if (retInst->getNumOperands() > 0) {
+                    Value *retOpnd = retInst->getOperand(0);
+                    (void) new StoreInst(retOpnd, retVal, retInst);
+                }
+                (void) new StoreInst(ConstantInt::getTrue(F.getContext()), 
+                                     retBool, retInst);
+                Conditional *cond = 0;
+                for (Function::BasicBlockListType::reverse_iterator bbI2 = bbI; bbI2 != e; bbI2++ ) {
+                    BasicBlock *cbb = &*bbI2;
+                    cond = idStructs->getConditional(cbb);
+                    if (!cond)
+                        continue;
+                    if (cond->hasChild(pbb))
+                        break;
+                }
+
+                BasicBlock *splitbb = cond->getExitBlock();
+                if (splitbb) {
+                    // skip past any blocks added during this transform
+                    // ie whose successor has one predecessor
+                    BasicBlock *succbb = splitbb->getTerminator()->getSuccessor(0);
+                    pred_iterator PI = pred_begin(succbb);
+                    PI++;
+                    while (PI == pred_end(succbb)) {
+                        splitbb = succbb;
+                        succbb = splitbb->getTerminator()->getSuccessor(0);
+                        PI = pred_begin(succbb);
+                        PI++;
+                    }
+
+                    mbb = splitbb->splitBasicBlock(splitbb->getTerminator(), 
+                                               splitbb->getName() + ".split");
+                } else {
+                    mbb = finalbb;
+                }
+                retInst->eraseFromParent();
+                (void) BranchInst::Create(mbb, pbb);
+            } else {
+                // process conditional merge block
+                // add conditional branch on early return boolean past
+                // controlling conditional's exit block or to return block
+
+                BasicBlock::InstListType::iterator I = pbb->getInstList().begin();
+                LoadInst *pld = dyn_cast<LoadInst>(&*I);
+                if (pld && dyn_cast<AllocaInst>(pld->getOperand(0)) == retBool)
+                    // If the first instruction is a load of the return
+                    // boolean, then this path has already been processed
+                    // and we are done processing this return.
+                    break;
+
+                BasicBlock *fbb = pbb->splitBasicBlock(pbb->begin(),
+                                       pbb->getName()+".split");
+                Conditional *cond = 0;
+                for (Function::BasicBlockListType::reverse_iterator bbI2 = bbI; bbI2 != e; bbI2++ ) {
+                    BasicBlock *cbb = &*bbI2;
+                    cond = idStructs->getConditional(cbb);
+                    if (!cond)
+                        continue;
+                    if (cond->hasChild(pbb))
+                        break;
+                    cond = 0;
+                }
+
+                BasicBlock *sbb = cond ? cond->getExitBlock() : 0;
+                if (sbb) {
+                    mbb = sbb->splitBasicBlock(sbb->getTerminator(),
+                                       sbb->getName()+".split");
+                } else {
+                    mbb = finalbb;
+                }
+                LoadInst *loadRetVal = new LoadInst(retBool, 
+                                                    pbb->getName()+".loadret", 
+                                                    false, 
+                                                    pbb->getTerminator());
+                (void) BranchInst::Create(mbb, fbb, loadRetVal, pbb->getTerminator());
+                pbb->getTerminator()->eraseFromParent();
+            }
+
+            // process next conditional merge block if not yet at final return
+            pbb = mbb;
+            if (pbb != finalbb)
+                pbb = pbb->getTerminator()->getSuccessor(0);
+        }
+    }
+
+    return changed;
+}
+
+void EarlyReturnElim::getAnalysisUsage(AnalysisUsage& AU) const
+{
+    // TODO: Preservation analysis info (e.g. using BasicBlockUtils.h's methods)
+
+    AU.addRequired<LoopInfo>();
+    AU.addRequired<DominatorTree>();
+    AU.addRequired<IdentifyStructures>();
+}
+
+void EarlyReturnElim::print(raw_ostream&, const Module*) const
+{
+    return;
+}
+
+char EarlyReturnElim::ID = 0;
+INITIALIZE_PASS_BEGIN(EarlyReturnElim,
+                      "early-return-elim",
+                      "Eliminate Early Returns for LunarGLASS",
+                      false,  // Whether it looks only at CFG
+                      false); // Whether it is an analysis pass
+INITIALIZE_PASS_DEPENDENCY(LoopInfo)
+INITIALIZE_PASS_DEPENDENCY(DominatorTree)
+INITIALIZE_PASS_DEPENDENCY(IdentifyStructures)
+INITIALIZE_PASS_END(EarlyReturnElim,
+                      "early-return-elim",
+                      "Eliminate Early Returns for LunarGLASS",
+                      false,  // Whether it looks only at CFG
+                      false); // Whether it is an analysis pass
+
+
+FunctionPass* gla_llvm::createEarlyReturnElimPass()
+{
+    return new EarlyReturnElim();
+}

--- a/Core/Passes/Util/ConditionalUtil.h
+++ b/Core/Passes/Util/ConditionalUtil.h
@@ -147,10 +147,24 @@ namespace gla_llvm {
             return isSelfContained() && AreEmptyBB(leftChildren) && AreEmptyBB(rightChildren);
         }
 
-        bool contains(BasicBlock* bb) const
+        bool hasChild(BasicBlock* bb) 
         {
-            return entry == bb || merge == bb
-                || Has(leftChildren, bb) || Has(rightChildren, bb);
+            for (SmallVectorImpl<BasicBlock*>::iterator i = leftChildren.begin(), e = leftChildren.end(); i != e; ++i) {
+                if (bb == *i)
+                    return true;
+            }
+
+            for (SmallVectorImpl<BasicBlock*>::iterator i = rightChildren.begin(), e = rightChildren.end(); i != e; ++i) {
+                if (bb == *i)
+                    return true;
+            }
+
+            return false;
+        }
+
+        bool contains(BasicBlock* bb)
+        {
+            return entry == bb || merge == bb || hasChild(bb);
         }
 
         // Whether the given conditional might have a cross-edge in it.
@@ -159,6 +173,9 @@ namespace gla_llvm {
         // Accessors.
         const BasicBlock* getEntryBlock() const { return entry; }
               BasicBlock* getEntryBlock()       { return entry; }
+
+        const BasicBlock* getExitBlock()  const { return exit; }
+              BasicBlock* getExitBlock()        { return exit; }
 
         const BasicBlock* getMergeBlock() const { return merge; }
               BasicBlock* getMergeBlock()       { return merge; }

--- a/test/baseResults/earlyReturn.frag.out
+++ b/test/baseResults/earlyReturn.frag.out
@@ -1,0 +1,239 @@
+
+Top IR:
+; ModuleID = 'Glslang'
+
+@g_nDebugMode = external addrspace(2) constant i32
+@result0 = external addrspace(2) constant <4 x float>
+@result1 = external addrspace(2) constant <4 x float>
+@g_flTest = external addrspace(2) constant float
+@g_nTest = external addrspace(2) constant i32
+@result2 = external addrspace(2) constant <4 x float>
+@result3 = external addrspace(2) constant <4 x float>
+@gl_FragColor = global <4 x float> zeroinitializer
+
+define fastcc void @main() {
+entry:
+  br label %mainBody
+
+mainBody:                                         ; preds = %entry
+  %gl_FragColor = call <4 x float> @"foo("()
+  store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor
+  br label %stage-epilogue
+
+stage-epilogue:                                   ; preds = %mainBody
+  br label %stage-exit
+
+stage-exit:                                       ; preds = %stage-epilogue
+  ret void
+}
+
+; Function Attrs: alwaysinline
+define internal fastcc <4 x float> @"ApplyDebugMode(b1;"(i1*) #0 {
+entry:
+  %vResult = alloca <4 x float>
+  %1 = load i32 addrspace(2)* @g_nDebugMode, !gla.uniform !0
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %then, label %else
+
+then:                                             ; preds = %entry
+  store i1 true, i1* %0
+  %vResult1 = load <4 x float> addrspace(2)* @result0, !gla.uniform !2
+  store <4 x float> %vResult1, <4 x float>* %vResult
+  br label %ifmerge
+
+else:                                             ; preds = %entry
+  store i1 false, i1* %0
+  %vResult2 = load <4 x float> addrspace(2)* @result1, !gla.uniform !3
+  store <4 x float> %vResult2, <4 x float>* %vResult
+  br label %ifmerge
+
+ifmerge:                                          ; preds = %else, %then
+  %3 = load <4 x float>* %vResult
+  ret <4 x float> %3
+
+post-return:                                      ; No predecessors!
+  unreachable
+}
+
+; Function Attrs: alwaysinline
+define internal fastcc <4 x float> @"foo("() #0 {
+entry:
+  %param = alloca i1
+  %vOutColor = alloca <4 x float>
+  %bReturn = alloca i1
+  %0 = load i32 addrspace(2)* @g_nDebugMode, !gla.uniform !0
+  %1 = icmp ne i32 %0, 1
+  br i1 %1, label %then, label %ifmerge4
+
+then:                                             ; preds = %entry
+  store i1 true, i1* %bReturn
+  %vOutColor2 = call <4 x float> @"ApplyDebugMode(b1;"(i1* %param)
+  %bReturn1 = load i1* %param
+  store i1 %bReturn1, i1* %bReturn
+  store <4 x float> %vOutColor2, <4 x float>* %vOutColor
+  %2 = load i1* %bReturn
+  br i1 %2, label %then3, label %ifmerge
+
+then3:                                            ; preds = %then
+  %3 = load <4 x float>* %vOutColor
+  ret <4 x float> %3
+
+post-return:                                      ; No predecessors!
+  unreachable
+
+ifmerge:                                          ; preds = %then
+  br label %ifmerge4
+
+ifmerge4:                                         ; preds = %entry, %ifmerge
+  %4 = load float addrspace(2)* @g_flTest, !gla.uniform !4
+  %5 = fcmp ogt float %4, 0.000000e+00
+  br i1 %5, label %then5, label %ifmerge10
+
+then5:                                            ; preds = %ifmerge4
+  %6 = load i32 addrspace(2)* @g_nTest, !gla.uniform !5
+  %7 = icmp sgt i32 %6, 0
+  br i1 %7, label %then6, label %else
+
+then6:                                            ; preds = %then5
+  %vOutColor7 = load <4 x float> addrspace(2)* @result2, !gla.uniform !6
+  store <4 x float> %vOutColor7, <4 x float>* %vOutColor
+  br label %ifmerge9
+
+else:                                             ; preds = %then5
+  %vOutColor8 = load <4 x float> addrspace(2)* @result3, !gla.uniform !7
+  store <4 x float> %vOutColor8, <4 x float>* %vOutColor
+  br label %ifmerge9
+
+ifmerge9:                                         ; preds = %else, %then6
+  br label %ifmerge10
+
+ifmerge10:                                        ; preds = %ifmerge4, %ifmerge9
+  %8 = load <4 x float>* %vOutColor
+  ret <4 x float> %8
+
+post-return11:                                    ; No predecessors!
+  unreachable
+}
+
+attributes #0 = { alwaysinline }
+
+!gla.uniforms = !{!0, !2, !3, !4, !5, !6, !7}
+!gla.entrypoint = !{!8}
+!gla.outputs = !{!9}
+
+!0 = metadata !{metadata !"g_nDebugMode", i32 14, i32* @g_nDebugMode_typeProxy, metadata !1}
+!1 = metadata !{i32 0, i32 0, i32 1024, null, i32 -1, i32 0, i32 -1, i32 0, i32 -1}
+!2 = metadata !{metadata !"result0", i32 14, <4 x float>* @result0_typeProxy, metadata !1}
+!3 = metadata !{metadata !"result1", i32 14, <4 x float>* @result1_typeProxy, metadata !1}
+!4 = metadata !{metadata !"g_flTest", i32 14, float* @g_flTest_typeProxy, metadata !1}
+!5 = metadata !{metadata !"g_nTest", i32 14, i32* @g_nTest_typeProxy, metadata !1}
+!6 = metadata !{metadata !"result2", i32 14, <4 x float>* @result2_typeProxy, metadata !1}
+!7 = metadata !{metadata !"result3", i32 14, <4 x float>* @result3_typeProxy, metadata !1}
+!8 = metadata !{metadata !"main", i32 17}
+!9 = metadata !{metadata !"gl_FragColor", i32 9, <4 x float>* @gl_FragColor_typeProxy, metadata !10}
+!10 = metadata !{i32 0, i32 0, i32 1024, null, i32 0, i32 43, i32 -1, i32 0, i32 -1}
+
+
+Bottom IR:
+; ModuleID = 'Glslang'
+
+@g_nDebugMode = external addrspace(2) constant i32
+@result0 = external addrspace(2) constant <4 x float>
+@result1 = external addrspace(2) constant <4 x float>
+@g_flTest = external addrspace(2) constant float
+@g_nTest = external addrspace(2) constant i32
+@result2 = external addrspace(2) constant <4 x float>
+@result3 = external addrspace(2) constant <4 x float>
+@gl_FragColor = global <4 x float> zeroinitializer
+
+define fastcc void @main() {
+entry:
+  %0 = load i32 addrspace(2)* @g_nDebugMode, align 4, !gla.uniform !0
+  %1 = icmp eq i32 %0, 0
+  %result0.val = load <4 x float> addrspace(2)* @result0, align 16
+  %result1.val = load <4 x float> addrspace(2)* @result1, align 16
+  %vResult.0.i.i = select i1 %1, <4 x float> %result0.val, <4 x float> %result1.val
+  %2 = load float addrspace(2)* @g_flTest, align 4, !gla.uniform !4
+  %3 = fcmp ogt float %2, 0.000000e+00
+  %4 = load i32 addrspace(2)* @g_nTest, align 4, !gla.uniform !5
+  %5 = icmp sgt i32 %4, 0
+  %result2.val = load <4 x float> addrspace(2)* @result2, align 16
+  %result3.val = load <4 x float> addrspace(2)* @result3, align 16
+  %vOutColor.1.i = select i1 %5, <4 x float> %result2.val, <4 x float> %result3.val
+  %select = select i1 %3, <4 x float> %vOutColor.1.i, <4 x float> %vResult.0.i.i
+  %select2 = select i1 %1, <4 x float> %result0.val, <4 x float> %select
+  store <4 x float> %select2, <4 x float>* @gl_FragColor, align 16
+  br label %stage-epilogue
+
+stage-epilogue:                                   ; preds = %entry
+  br label %stage-exit
+
+stage-exit:                                       ; preds = %stage-epilogue
+  ret void
+}
+
+!gla.uniforms = !{!0, !2, !3, !4, !5, !6, !7}
+!gla.entrypoint = !{!8}
+!gla.outputs = !{!9}
+
+!0 = metadata !{metadata !"g_nDebugMode", i32 14, i32* @g_nDebugMode_typeProxy, metadata !1}
+!1 = metadata !{i32 0, i32 0, i32 1024, null, i32 -1, i32 0, i32 -1, i32 0, i32 -1}
+!2 = metadata !{metadata !"result0", i32 14, <4 x float>* @result0_typeProxy, metadata !1}
+!3 = metadata !{metadata !"result1", i32 14, <4 x float>* @result1_typeProxy, metadata !1}
+!4 = metadata !{metadata !"g_flTest", i32 14, float* @g_flTest_typeProxy, metadata !1}
+!5 = metadata !{metadata !"g_nTest", i32 14, i32* @g_nTest_typeProxy, metadata !1}
+!6 = metadata !{metadata !"result2", i32 14, <4 x float>* @result2_typeProxy, metadata !1}
+!7 = metadata !{metadata !"result3", i32 14, <4 x float>* @result3_typeProxy, metadata !1}
+!8 = metadata !{metadata !"main", i32 17}
+!9 = metadata !{metadata !"gl_FragColor", i32 9, <4 x float>* @gl_FragColor_typeProxy, metadata !10}
+!10 = metadata !{i32 0, i32 0, i32 1024, null, i32 0, i32 43, i32 -1, i32 0, i32 -1}
+#version 140
+// LunarGOO output
+uniform int g_nDebugMode;
+uniform vec4 result0;
+uniform vec4 result1;
+uniform float g_flTest;
+uniform int g_nTest;
+uniform vec4 result2;
+uniform vec4 result3;
+const int C_0 = 0;
+const float C_0d0 = 0.0;
+
+void main()
+{
+	bool H_zlpyes = g_nDebugMode == C_0;
+	vec4 vResult = H_zlpyes ? result0 : result1;
+	bool H_x8n3bu1 = g_flTest > C_0d0;
+	bool H_bkvenx = g_nTest > C_0;
+	vec4 vOutColor = H_bkvenx ? result2 : result3;
+	vec4 select = H_x8n3bu1 ? vOutColor : vResult;
+	vec4 select1 = H_zlpyes ? result0 : select;
+	gl_FragColor = select1;
+	
+}
+
+#version 140
+// LunarGOO output
+uniform int g_nDebugMode;
+uniform vec4 result0;
+uniform vec4 result1;
+uniform float g_flTest;
+uniform int g_nTest;
+uniform vec4 result2;
+uniform vec4 result3;
+const int C_0 = 0;
+const float C_0d0 = 0.0;
+
+void main()
+{
+	bool H_zlpyes = g_nDebugMode == C_0;
+	vec4 vResult = H_zlpyes ? result0 : result1;
+	bool H_x8n3bu = g_flTest > C_0d0;
+	bool H_bkvenx = g_nTest > C_0;
+	vec4 vOutColor = H_bkvenx ? result2 : result3;
+	vec4 vOutColor1 = H_x8n3bu ? vOutColor : vResult;
+	vec4 select = H_zlpyes ? result0 : vOutColor1;
+	gl_FragColor = select;
+	
+}
+

--- a/test/baseResults/forwardFun.frag.out
+++ b/test/baseResults/forwardFun.frag.out
@@ -124,8 +124,8 @@ entry:
   %3 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %2, <4 x i32> zeroinitializer)
   %4 = load float addrspace(2)* @d, align 4, !gla.uniform !5
   %5 = fcmp olt float %4, 0x4010CCCCC0000000
-  %f45 = select i1 %5, float 0x3FF3333340000000, float 4.500000e+00
-  %6 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %f45, <4 x i32> zeroinitializer)
+  %merge.i = select i1 %5, float 0x3FF3333340000000, float 4.500000e+00
+  %6 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %merge.i, <4 x i32> zeroinitializer)
   %gl_FragColor = fmul <4 x float> %3, %6, !gla.precision !8
   store <4 x float> %gl_FragColor, <4 x float>* @gl_FragColor, align 16
   br label %stage-epilogue
@@ -172,9 +172,9 @@ void main()
 	mediump float H_9ws3cr = BaseColor.x + BaseColor.y;
 	vec4 H_qwppqe = vec4(H_9ws3cr);
 	bool H_zdlq2v = d < C_4d2;
-	float H_8iih7k1 = H_zdlq2v ? C_1d2 : C_4d5;
-	vec4 H_a1eyhf1 = vec4(H_8iih7k1);
-	mediump vec4 Ll_FragColor1 = H_a1eyhf1 * H_qwppqe;
+	float merge = H_zdlq2v ? C_1d2 : C_4d5;
+	vec4 H_yhyg771 = vec4(merge);
+	mediump vec4 Ll_FragColor1 = H_qwppqe * H_yhyg771;
 	gl_FragColor = Ll_FragColor1;
 	
 }
@@ -194,9 +194,9 @@ void main()
 	mediump float H_9ws3cr = BaseColor.x + BaseColor.y;
 	vec4 H_qwppqe = vec4(H_9ws3cr);
 	bool H_zdlq2v = d < C_4d2;
-	float H_8iih7k = H_zdlq2v ? C_1d2 : C_4d5;
-	vec4 H_3uuahw1 = vec4(H_8iih7k);
-	mediump vec4 Ll_FragColor = H_3uuahw1 * H_qwppqe;
+	float merge = H_zdlq2v ? C_1d2 : C_4d5;
+	vec4 H_yhyg771 = vec4(merge);
+	mediump vec4 Ll_FragColor = H_qwppqe * H_yhyg771;
 	gl_FragColor = Ll_FragColor;
 	
 }

--- a/test/baseResults/functionCall.frag.out
+++ b/test/baseResults/functionCall.frag.out
@@ -154,8 +154,8 @@ entry:
   %3 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %2, <4 x i32> zeroinitializer)
   %4 = load float addrspace(2)* @d, align 4, !gla.uniform !0
   %5 = fcmp olt float %4, 0x4010CCCCC0000000
-  %f48 = select i1 %5, float 0x3FF3333340000000, float 4.500000e+00
-  %6 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %f48, <4 x i32> zeroinitializer)
+  %merge.i = select i1 %5, float 0x3FF3333340000000, float 4.500000e+00
+  %6 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %merge.i, <4 x i32> zeroinitializer)
   %7 = fcmp olt float %4, 4.500000e+00
   br i1 %7, label %then.i, label %ifmerge.i
 
@@ -165,8 +165,8 @@ then.i:                                           ; preds = %entry
 ifmerge.i:                                        ; preds = %entry
   br label %"missingReturn(.exit"
 
-"missingReturn(.exit":                            ; preds = %ifmerge.i, %then.i
-  %8 = phi float [ 0.000000e+00, %ifmerge.i ], [ %4, %then.i ]
+"missingReturn(.exit":                            ; preds = %then.i, %ifmerge.i
+  %8 = phi float [ %4, %then.i ], [ 0.000000e+00, %ifmerge.i ]
   %9 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %8, <4 x i32> zeroinitializer)
   %10 = fmul <4 x float> %3, %6
   %gl_FragColor = fmul <4 x float> %10, %9
@@ -215,8 +215,8 @@ void main()
 	float H_9ws3cr = BaseColor.x + BaseColor.y;
 	vec4 H_qwppqe = vec4(H_9ws3cr);
 	bool H_zdlq2v = d < C_4d2;
-	float H_8iih7k1 = H_zdlq2v ? C_1d2 : C_4d5;
-	vec4 H_a1eyhf1 = vec4(H_8iih7k1);
+	float merge = H_zdlq2v ? C_1d2 : C_4d5;
+	vec4 H_yhyg771 = vec4(merge);
 	bool H_2bsr8u = d < C_4d5;
 	if (H_2bsr8u) {
 		Lg_1 = d;
@@ -225,8 +225,8 @@ void main()
 	}
 	
 	vec4 H_zt5qpl = vec4(Lg_1);
-	vec4 H_m9v3pf = H_a1eyhf1 * H_qwppqe;
-	vec4 Ll_FragColor1 = H_m9v3pf * H_zt5qpl;
+	vec4 H_lobwrj1 = H_qwppqe * H_yhyg771;
+	vec4 Ll_FragColor1 = H_lobwrj1 * H_zt5qpl;
 	gl_FragColor = Ll_FragColor1;
 	
 }
@@ -246,13 +246,13 @@ void main()
 	float H_9ws3cr = BaseColor.x + BaseColor.y;
 	vec4 H_qwppqe = vec4(H_9ws3cr);
 	bool H_zdlq2v = d < C_4d2;
-	float H_8iih7k = H_zdlq2v ? C_1d2 : C_4d5;
-	vec4 H_3uuahw1 = vec4(H_8iih7k);
+	float merge = H_zdlq2v ? C_1d2 : C_4d5;
+	vec4 H_yhyg771 = vec4(merge);
 	bool H_2bsr8u = d < C_4d5;
 	float H_bu6uh9 = H_2bsr8u ? d : C_0d0;
 	vec4 H_a607fc = vec4(H_bu6uh9);
-	vec4 H_m9v3pf = H_3uuahw1 * H_qwppqe;
-	vec4 Ll_FragColor = H_a607fc * H_m9v3pf;
+	vec4 H_lobwrj = H_qwppqe * H_yhyg771;
+	vec4 Ll_FragColor = H_a607fc * H_lobwrj;
 	gl_FragColor = Ll_FragColor;
 	
 }

--- a/test/baseResults/functionSemantics.frag.out
+++ b/test/baseResults/functionSemantics.frag.out
@@ -225,10 +225,10 @@ then.i:                                           ; preds = %entry
 ifmerge.i:                                        ; preds = %entry
   br label %"foo3(.exit"
 
-"foo3(.exit":                                     ; preds = %ifmerge.i, %then.i
-  %2 = phi float [ 1.397317e+06, %then.i ], [ 2.397317e+06, %ifmerge.i ]
-  %3 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %2, <4 x i32> zeroinitializer)
-  store <4 x float> %3, <4 x float>* @gl_FragColor, align 16
+"foo3(.exit":                                     ; preds = %then.i, %ifmerge.i
+  %earlyretval.0.i = phi float [ 1.397317e+06, %then.i ], [ 2.397317e+06, %ifmerge.i ]
+  %2 = call <4 x float> @llvm.gla.fSwizzle.v4f32.f32.v4i32(float %earlyretval.0.i, <4 x i32> zeroinitializer)
+  store <4 x float> %2, <4 x float>* @gl_FragColor, align 16
   br label %stage-epilogue
 
 stage-epilogue:                                   ; preds = %"foo3(.exit"
@@ -265,17 +265,17 @@ const float C_2397317d0 = 2397317.0;
 
 void main()
 {
-	float Lg_1;
+	float earlyretval;
 	bool H_3xblpb1 = u > C_3d2;
 	if (H_3xblpb1) {
 		discard;
-		Lg_1 = C_1397317d0;
+		earlyretval = C_1397317d0;
 	} else {
-		Lg_1 = C_2397317d0;
+		earlyretval = C_2397317d0;
 	}
 	
-	vec4 H_zt5qpl = vec4(Lg_1);
-	gl_FragColor = H_zt5qpl;
+	vec4 H_xtkctx = vec4(earlyretval);
+	gl_FragColor = H_xtkctx;
 	
 }
 

--- a/test/earlyReturn.frag
+++ b/test/earlyReturn.frag
@@ -1,0 +1,57 @@
+#version 140
+
+uniform int g_nDebugMode;
+uniform int g_nTest;
+uniform float g_flTest;
+
+uniform vec4 result0;
+uniform vec4 result1;
+uniform vec4 result2;
+uniform vec4 result3;
+vec4 ApplyDebugMode( out bool bReturn )
+{
+    vec4 vResult;
+    if ( g_nDebugMode == 0 )
+    {
+        bReturn = true;
+        vResult = result0;
+    }
+    else
+    {
+        bReturn = false;
+        vResult = result1;
+    }
+    return vResult;
+}
+
+vec4 foo()
+{
+    vec4 vOutColor;
+    if ( g_nDebugMode != 1 )
+    {
+        bool bReturn = true;
+        vOutColor = ApplyDebugMode( bReturn );
+        if ( bReturn )
+            return vOutColor;
+    }
+
+    if ( g_flTest > 0.0 )
+    {
+        if ( g_nTest > 0 )
+        {
+            vOutColor = result2;
+        }
+        else
+        {
+            vOutColor = result3;
+        }
+
+    }
+    return vOutColor;
+}
+
+void main()
+{
+    gl_FragColor = foo();
+}
+

--- a/test/runtests
+++ b/test/runtests
@@ -25,6 +25,7 @@ ISOLATEDTESTS=(flowControl.frag \
        prepost.frag            \
        swizzle.frag            \
        simpleFunctionCall.frag \
+       earlyReturn.frag        \
        functionCall.frag       \
        functionSemantics.frag  \
        forwardFun.frag         \


### PR DESCRIPTION
fixes #26 
Convert early returns into equivalent control flow in non-main functions. This is done so that the control flow in non-main functions is reducible. This allows the control flow to easily be converted into structured control flow constructs after it is inlined into larger functions. It also makes subsequent analysis, optimizations and code generation more efficient and effective. Logic already existed to deal effectively with early returns in main, so they are not addressed here.
